### PR TITLE
🧹[#21] startDate의 데이터 타입을 String?으로 변경합니다.

### DIFF
--- a/UMM/UMM.xcdatamodeld/UMM.xcdatamodel/contents
+++ b/UMM/UMM.xcdatamodeld/UMM.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="Expense" representedClassName="Expense" syncable="YES" codeGenerationType="class">
         <attribute name="info" optional="YES" attributeType="String"/>
         <attribute name="participant" optional="YES" attributeType="Transformable" customClassName="[String]"/>
@@ -12,7 +12,7 @@
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="participantArray" optional="YES" attributeType="Transformable" customClassName="[String]"/>
-        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="startDate" optional="YES" attributeType="String"/>
         <relationship name="expenseArray" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Expense" inverseName="travel" inverseEntity="Expense"/>
     </entity>
     <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">


### PR DESCRIPTION
## 👀 이슈
- #21 

## 💡 작업 내용
- Travel Entity의 startDate의 데이터 타입을 String?으로 변경

## 📱스크린샷
<img width="1170" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/9229f312-3c6c-4b22-bd59-99f19860d569">


## 🚨 참고 사항

여행 안에서의 정산은 일자까지만 필요할꺼 같아서 기존에 Date?타입을 String?타입으로 변경하였습니다.
