### PR TITLE
:broom:[#24] UMMApp에서 환경객체 삭제

### DIFF
--- a/UMM/UMMApp.swift
+++ b/UMM/UMMApp.swift
@@ -9,11 +9,9 @@ import SwiftUI
 
 @main
 struct UMMApp: App {
-    let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }
 }


### PR DESCRIPTION
## 👀 이슈
- #24

## 💡 작업 내용
- UMMApp.swift 파일에서 환경 객체 생성하고 뷰에 주입하는 라인을 삭제했습니다.

## 📱스크린샷
<img width="333" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/107789649/310e0941-b0df-4c53-85cc-f71ef93bba53">

## 🚨 참고 사항
- 뷰모델 안에서는 PersistenceController의 싱글톤으로 viewContext에 접근해주세요!
