### PR TITLE
:broom:[#30] RecordViewModel의 voiceSentenceChoicer 변수 앞에 private을 붙였습니다.

### DIFF
--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -38,7 +38,7 @@ final class RecordViewModel: ObservableObject {
         "오로나민씨 2000원",
         "오이 3000원"
     ]
-    var voiceSentenceChoicer: Int = 0
+    private var voiceSentenceChoicer: Int = 0
     
     func divideVoiceSentence() {
         guard voiceSentence.count > 0 else {


### PR DESCRIPTION
## 👀 이슈
- #30

## 💡 작업 내용
- RecordViewModel의 voiceSentenceChoicer 변수 앞에 private을 붙였습니다.

## 📱스크린샷
-

## 🚨 참고 사항
- @GYURI-PARK 의 코드 리뷰를 반영해서, 뷰 모델 안의 메서드에서만 사용되는 변수에 private을 붙였습니다.
- 테스트용 버튼의 동작에 관여하는 메서드 alterVoiceSentence()에서 사용되는 변수입니다.