### PR TITLE
⚡️[#20] STT 기능을 구현합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -391,15 +391,18 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UMM/Preview Content\"";
-				DEVELOPMENT_TEAM = NM2S86642U;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = test;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Need to convert sound data into text data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -421,15 +424,18 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UMM/Preview Content\"";
-				DEVELOPMENT_TEAM = NM2S86642U;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = test;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Need to convert sound data into text data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/UMM/UMMApp.swift
+++ b/UMM/UMMApp.swift
@@ -12,8 +12,7 @@ struct UMMApp: App {
     let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
-//            ContentView()
-            RecordView()
+            ContentView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }

--- a/UMM/UMMApp.swift
+++ b/UMM/UMMApp.swift
@@ -12,7 +12,8 @@ struct UMMApp: App {
     let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
-            ContentView()
+//            ContentView()
+            RecordView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }

--- a/UMM/View/RecordView.swift
+++ b/UMM/View/RecordView.swift
@@ -89,18 +89,33 @@ struct RecordView: View {
     }
     
     var recordButton: some View {
-        Button {
+        VStack {
+            Button {
+                viewModel.invalidateButton()
+                do {
+                    try viewModel.startRecording()
+                } catch {
+                    print("error while recording: \(error.localizedDescription)")
+                }
+            } label: {
+                ZStack {
+                    Circle()
+                        .fill(isDetectingPress ? .blue : .gray)
+                        .frame(width: 50, height: 50)
+                    Image(systemName: "record.circle")
+                        .foregroundStyle(Color.white)
+                }
+            }
+            .simultaneousGesture(continuousPress)
             
-        } label: {
             ZStack {
-                Circle()
-                    .fill(isDetectingPress ? .blue : .gray)
-                    .frame(width: 50, height: 50)
-                Image(systemName: "record.circle")
-                    .foregroundStyle(Color.white)
+                Rectangle()
+                    .frame(width: 300, height: 150)
+                    .foregroundStyle(Color.yellow)
+                
+                Text(viewModel.voiceSentenceTemp)
             }
         }
-        .simultaneousGesture(continuousPress)
     }
 }
 

--- a/UMM/View/RecordView.swift
+++ b/UMM/View/RecordView.swift
@@ -72,6 +72,9 @@ struct RecordView: View {
             .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .local))
             .updating($isDetectingPress) { value, gestureState, _ in
                 switch value {
+                case .first(true):
+                    gestureState = true
+                    print("녹음 시작")
                 case .second(true, nil):
                     gestureState = true
                     print("녹음 중")
@@ -80,7 +83,7 @@ struct RecordView: View {
                 }
             }.onEnded { value in
                 switch value {
-                case .second( _, _):
+                case .second:
                     print("녹음완료")
                     print(viewModel.voiceSentenceTemp)
                 default:
@@ -101,7 +104,7 @@ struct RecordView: View {
             } label: {
                 ZStack {
                     Circle()
-                        .fill(isDetectingPress ? .blue : .gray)
+                        .fill(isDetectingPress ? .gray : .blue)
                         .frame(width: 50, height: 50)
                     Image(systemName: "record.circle")
                         .foregroundStyle(Color.white)

--- a/UMM/View/RecordView.swift
+++ b/UMM/View/RecordView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct RecordView: View {
     
     @ObservedObject var viewModel = RecordViewModel()
+    @GestureState private var isDetectingPress = false
     
     var body: some View {
         VStack(spacing: 30) {
@@ -17,6 +18,7 @@ struct RecordView: View {
             sentenceView
             livePropertyView
             sentenceAlterButton
+            recordButton
         }
         .onAppear {
             viewModel.divideVoiceSentence()
@@ -63,6 +65,42 @@ struct RecordView: View {
                     .foregroundStyle(.white)
             }
         }
+    }
+    
+    var continuousPress: some Gesture {
+        LongPressGesture(minimumDuration: 0.1)
+            .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .local))
+            .updating($isDetectingPress) { value, gestureState, _ in
+                switch value {
+                case .second(true, nil):
+                    gestureState = true
+                    print("녹음 중")
+                default:
+                    break
+                }
+            }.onEnded { value in
+                switch value {
+                case .second(_, _):
+                    print("녹음완료")
+                default:
+                    break
+                }
+            }
+    }
+    
+    var recordButton: some View {
+        Button {
+            
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(.blue)
+                    .frame(width: 50, height: 50)
+                Image(systemName: "record.circle")
+                    .foregroundStyle(Color.white)
+            }
+        }
+        .simultaneousGesture(continuousPress)
     }
 }
 

--- a/UMM/View/RecordView.swift
+++ b/UMM/View/RecordView.swift
@@ -94,7 +94,7 @@ struct RecordView: View {
         } label: {
             ZStack {
                 Circle()
-                    .fill(.blue)
+                    .fill(isDetectingPress ? .blue : .gray)
                     .frame(width: 50, height: 50)
                 Image(systemName: "record.circle")
                     .foregroundStyle(Color.white)

--- a/UMM/View/RecordView.swift
+++ b/UMM/View/RecordView.swift
@@ -80,8 +80,9 @@ struct RecordView: View {
                 }
             }.onEnded { value in
                 switch value {
-                case .second(_, _):
+                case .second( _, _):
                     print("녹음완료")
+                    print(viewModel.voiceSentenceTemp)
                 default:
                     break
                 }
@@ -110,7 +111,7 @@ struct RecordView: View {
             
             ZStack {
                 Rectangle()
-                    .frame(width: 300, height: 150)
+                    .frame(width: 200, height: 50)
                     .foregroundStyle(Color.yellow)
                 
                 Text(viewModel.voiceSentenceTemp)

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -427,4 +427,6 @@ final class RecordViewModel: ObservableObject {
         }
         voiceSentence = RecordViewModel.voiceSentenceArray[voiceSentenceChoicer]
     }
+    
+    
 }

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -433,7 +433,7 @@ final class RecordViewModel: ObservableObject {
         voiceSentence = RecordViewModel.voiceSentenceArray[voiceSentenceChoicer]
     }
     
-    //MARK: 녹음 기능
+    // MARK: 녹음 기능
     func updateTranscribedString(transcribedString: String) {
         voiceSentenceTemp = transcribedString
     }
@@ -459,7 +459,7 @@ final class RecordViewModel: ObservableObject {
         let inputNode = audioEngine.inputNode
         inputNode.removeTap(onBus: 0)
         let recordingFormat = inputNode.outputFormat(forBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, _: AVAudioTime) in
             self.recognitionRequest?.append(buffer)
         }
         

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -489,8 +489,4 @@ final class RecordViewModel: ObservableObject {
             }
         }
     }
-    
-    func finishRecording() throws {
-        audioEngine.stop()
-    }
 }

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -6,10 +6,15 @@
 //
 
 import Foundation
+import SwiftUI
+import Speech
+import AVFoundation
 
 final class RecordViewModel: ObservableObject {
     let viewContext = PersistenceController.shared.container.viewContext
     @Published var voiceSentence: String = RecordViewModel.voiceSentenceArray[0]
+    @Published var voiceSentenceTemp = ""
+    @Published var buttonPressed = false
     @Published var info: String?
     @Published var infoCategory: ExpenseInfoCategory = .unknown
     @Published var payAmount: Double = -1
@@ -428,5 +433,64 @@ final class RecordViewModel: ObservableObject {
         voiceSentence = RecordViewModel.voiceSentenceArray[voiceSentenceChoicer]
     }
     
+    //MARK: 녹음 기능
+    func updateTranscribedString(transcribedString: String) {
+        voiceSentenceTemp = transcribedString
+    }
     
+    private let audioEngine = AVAudioEngine()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko_KR"))
+    private var recognitionTask: SFSpeechRecognitionTask?
+    
+    func invalidateButton() {
+        buttonPressed = true
+    }
+    
+    func startRecording() throws {
+        
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        
+        let inputNode = audioEngine.inputNode
+        inputNode.removeTap(onBus: 0)
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+            self.recognitionRequest?.append(buffer)
+        }
+        
+        audioEngine.prepare()
+        try audioEngine.start()
+        
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest = recognitionRequest else { fatalError("Unable to create a SFSpeechAudioBufferRecognitionRequest object") }
+        recognitionRequest.shouldReportPartialResults = true
+        
+        if speechRecognizer?.supportsOnDeviceRecognition ?? false {
+            recognitionRequest.requiresOnDeviceRecognition = true
+        }
+        
+        recognitionTask = speechRecognizer?.recognitionTask(with: recognitionRequest) { result, error in
+            if let result = result {
+                DispatchQueue.main.async {
+                    let transcribedString = result.bestTranscription.formattedString
+                    self.updateTranscribedString(transcribedString: transcribedString)
+                }
+            }
+            if error != nil {
+                self.audioEngine.stop()
+                inputNode.removeTap(onBus: 0)
+                self.recognitionRequest = nil
+                self.recognitionTask = nil
+            }
+        }
+    }
+    
+    func finishRecording() throws {
+        audioEngine.stop()
+    }
 }


### PR DESCRIPTION
## 👀 이슈
- #20 

## 💡 작업 내용
- 임의의 녹음 버튼을 누르고 있는 동안만 녹음이 가능하도록 구현

## 📱스크린샷

https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/572c404e-f9c2-4f8f-9270-de83258db94f

## 🚨 참고 사항

- 변환된 문장은 `voiceSentenceTemp`에 저장함
- 제스쳐 두개를 사용하다보니 두번째 눌렀을 때부터 기능 작동함 (방법 찾으면 수정 예정 아직은 못찾음)
- 빠르게 말하면 글자 하나하나씩이 아닌 단어 단위로 한번에 띄워지는데 이것도 방법 찾으면 추가하겠음

## (Optional) 🤔 고민한 점

 LongPressGesture의 minimumDuration의 값을 .infinity로 설정하면 사용자가 원하는 만큼 제스처를 유지할 수 있었지만 제스처가 끝난 상태(손을 뗀 후)를 인식하지 못했다. 

```swift
.gesture(
                LongPressGesture(minimumDuration: .infinity)
                    .updating($press) { currentState, gestureState, transaction in
                        gestureState = currentState
                    }
                    .onEnded { value in
                        show.toggle()
                        print("끝")
                    }
            )
```
</br>
위와 같이 코드를 짰었는데 onEnded 매서드가 실행되지 않았다. </br>
그래서 .sequenced를 사용해 Long Press Gesture 전에 하나의 제스처를 더 추가하는 방식으로 문제를 해결하고자 했다. </br>

```swift
var continuousPress: some Gesture {
        LongPressGesture(minimumDuration: 0.1)
            .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .local))
            .updating($isDetectingContinuousPress) { value, gestureState, _ in
                switch value {
                case .second(true, nil):
                    gestureState = true
                    print("녹음 중")
                default:
                    break
                }
            }.onEnded { value in
                switch value {
                case .second(_, _):
                    print("녹음 완료")
                default:
                    break
                }
            }
    }
```

</br>

위와 같이 DragGesture을 첫 번째(.first) 제스처로 삽입해주어서 `녹음 완료`를 출력할 수 있게 되었지만 위에서 말한 것처럼 두번 째 눌렀을 때부터 기능 작동한다...</br>
방법을 찾으면 수정하겠음......