### PR TITLE
🧩[#41] 버튼 컴포넌트를 생성하여 간편하게 쓰일 수 있도록 합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C17550522AD54FB000A61BE5 /* TravelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550512AD54FB000A61BE5 /* TravelListView.swift */; };
 		C17550542AD54FC900A61BE5 /* AddTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550532AD54FC900A61BE5 /* AddTravelView.swift */; };
 		C17550592AD57B6500A61BE5 /* AddTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550582AD57B6500A61BE5 /* AddTravelViewModel.swift */; };
+		C190C20C2ADCD47E0099EE3A /* ButtomTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190C20B2ADCD47E0099EE3A /* ButtomTheme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
 		C17550512AD54FB000A61BE5 /* TravelListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListView.swift; sourceTree = "<group>"; };
 		C17550532AD54FC900A61BE5 /* AddTravelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTravelView.swift; sourceTree = "<group>"; };
 		C17550582AD57B6500A61BE5 /* AddTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTravelViewModel.swift; sourceTree = "<group>"; };
+		C190C20B2ADCD47E0099EE3A /* ButtomTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtomTheme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 		571A42682ACE857500FA3D2B /* UMM */ = {
 			isa = PBXGroup;
 			children = (
+				C190C20A2ADCD4520099EE3A /* DesignSystem */,
 				571A42692ACE857500FA3D2B /* UMMApp.swift */,
 				C17550572AD5519800A61BE5 /* ViewModel */,
 				C17550562AD5518C00A61BE5 /* View */,
@@ -145,6 +148,14 @@
 				57A65D112AD7D5D500131266 /* RecordViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C190C20A2ADCD4520099EE3A /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				C190C20B2ADCD47E0099EE3A /* ButtomTheme.swift */,
+			);
+			path = DesignSystem;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -243,6 +254,7 @@
 			files = (
 				571A426C2ACE857500FA3D2B /* ContentView.swift in Sources */,
 				57A65D122AD7D5D500131266 /* RecordViewModel.swift in Sources */,
+				C190C20C2ADCD47E0099EE3A /* ButtomTheme.swift in Sources */,
 				57A65D082AD7D4D100131266 /* CharacterForm.swift in Sources */,
 				57A65D182AD7DDA700131266 /* RecordView.swift in Sources */,
 				57C41DFC2AD4F1EB00345253 /* Persistence.swift in Sources */,

--- a/UMM/DesignSystem/ButtomTheme.swift
+++ b/UMM/DesignSystem/ButtomTheme.swift
@@ -94,7 +94,7 @@ struct MediumButtonMain: View {
     }
 }
 
-struct MediumButtonBlack: View {
+struct MediumButtonActive: View {
     
     var title: String
     var action: () -> Void
@@ -236,7 +236,7 @@ struct ButtomThemeTemplate: View {
             
             HStack {
                 MediumButtonUnactive(title: "저장하기") {}
-                MediumButtonBlack(title: "저장하기") {}
+                MediumButtonActive(title: "저장하기") {}
             }
 
             HStack {

--- a/UMM/DesignSystem/ButtomTheme.swift
+++ b/UMM/DesignSystem/ButtomTheme.swift
@@ -1,0 +1,257 @@
+//
+//  ButtomTheme.swift
+//  UMM
+//
+//  Created by GYURI PARK on 2023/10/16.
+//
+
+import SwiftUI
+
+struct LargeButtonActive: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+            
+        }
+        .background(Color.black)
+        .cornerRadius(12)
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+        .padding(.bottom, 45)
+        .background(Color.white)
+    }
+}
+
+struct LargeButtonUnactive: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+            
+        }
+        .background(Color.gray)
+        .cornerRadius(12)
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+        .padding(.bottom, 45)
+        .background(Color.white)
+    }
+}
+
+struct MediumButtonWhite: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.black)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+
+        }
+        .background(Color.white)
+        .cornerRadius(12)
+        .padding(.leading, 16)
+    }
+}
+
+struct MediumButtonMain: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+        }
+        .background(Color.red)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+    }
+}
+
+struct MediumButtonBlack: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+        }
+        .background(Color.black)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+    }
+}
+
+struct MediumButtonUnactive: View {
+    
+    var title: String
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 17)
+                .frame(maxWidth: .infinity)
+        }
+        .background(Color.gray)
+        .cornerRadius(12)
+        .padding(.leading, 16)
+    }
+}
+
+struct NextButtonActive: View {
+    
+    var title: String = "다음"
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                Image(systemName: "chevron.right")
+            }
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 13)
+                .padding(.leading, 28)
+                .padding(.trailing, 20)
+                .frame(width: 116, height: 50, alignment: .center)
+        }
+        .background(Color.black)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+        .padding(.bottom, 45)
+    }
+}
+
+struct NextButtonUnactive: View {
+    
+    var title: String = "다음"
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                Image(systemName: "chevron.right")
+            }
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 13)
+                .padding(.leading, 28)
+                .padding(.trailing, 20)
+                .frame(width: 116, height: 50, alignment: .center)
+        }
+        .background(Color.gray)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+        .padding(.bottom, 45)
+    }
+}
+
+struct DoneButtonActive: View {
+    
+    var title: String = "완료"
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 13)
+                .frame(width: 116, height: 50, alignment: .center)
+        }
+        .background(Color.black)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+        .padding(.bottom, 45)
+    }
+}
+
+struct DoneButtonUnactive: View {
+    
+    var title: String = "완료"
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+                Text(title)
+            
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .padding(.vertical, 13)
+                .frame(width: 116, height: 50, alignment: .center)
+        }
+        .background(Color.gray)
+        .cornerRadius(12)
+        .padding(.trailing, 16)
+        .padding(.bottom, 45)
+    }
+}
+
+struct ButtomThemeTemplate: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            LargeButtonActive(title: "저장하기") {}
+            LargeButtonUnactive(title: "저장하기") {}
+            
+            HStack {
+                MediumButtonWhite(title: "저장하기") {}
+                MediumButtonMain(title: "저장하기") {}
+            }
+            
+            HStack {
+                MediumButtonUnactive(title: "저장하기") {}
+                MediumButtonBlack(title: "저장하기") {}
+            }
+
+            HStack {
+                NextButtonActive {}
+                NextButtonUnactive {}
+            }
+            
+            HStack {
+                DoneButtonActive {}
+                DoneButtonUnactive {}
+            }
+        }
+    }
+}
+
+#Preview {
+    ButtomThemeTemplate()
+}

--- a/UMM/View/AddTravelView.swift
+++ b/UMM/View/AddTravelView.swift
@@ -24,7 +24,7 @@ struct AddTravelView: View {
                 calendarHeader
                 calendarGridView
             }
-
+            
             Spacer()
         }
     }


### PR DESCRIPTION
## 👀 이슈
- #41

## 💡 작업 내용
- 재사용되는 버튼을 구조체로 만들어 디자인 시스템 구현

## 📱스크린샷

<img width="282" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/ba3ea337-1dfc-4e57-8d7f-55ca243c5d5b">


## 🚨 참고 사항

- 폰트와 Color는 에셋 추가 후 수정 예정입니다.
- 변수명은 다음과 같습니다.
<img width="619" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/08746024-e96f-4938-b37c-613dc5aded8d">

- `LargeButtonActive`와 `LargeButtonUnactive`의 경우에는 스크롤 뷰에서 뒤에 글자나 다른 요소들이 비춰지는 것을 방지하기 위해 background로 white를 설정하였습니다.
- NextButton과 DoneButton의 경우에는 크기는 고정이라서, frame을 사용하였고, 오른쪽과 아래쪽 패딩을 사용해 Spacer()를 활용하면 항상 오른쪽 하단에 위치할 수 있도록 하였습니다.


### 사용법

```swift
NavigationLink(destination: RecordView()) {
                MediumButtonBlack(title: “저장하기, action: {
                })
}
```
## 🤔 고민한 점

- 화면 크기에 대응할 수 있는 버튼을 만들기 위해 최대한 padding을 사용하였습니다.