### PR TITLE
⚡️[#47][#58] AddTravelView와 AddMemberView 데이터 선택 기능을 구현합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		C179660E2ADD6BF90036E866 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C179660D2ADD6BF90036E866 /* Color+Extension.swift */; };
 		C190C2032ADAAE2C0099EE3A /* AddMemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190C2022ADAAE2C0099EE3A /* AddMemberView.swift */; };
 		C190C20C2ADCD47E0099EE3A /* ButtonTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190C20B2ADCD47E0099EE3A /* ButtonTheme.swift */; };
+		C19AFADF2ADEAEC80037A5F5 /* CompleteAddTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFADE2ADEAEC70037A5F5 /* CompleteAddTravelView.swift */; };
 		E2D5C05C2ADD921400907501 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05B2ADD921400907501 /* MainView.swift */; };
 		E2D5C05E2ADD922000907501 /* DummyRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05D2ADD922000907501 /* DummyRecordView.swift */; };
 		E2D5C0602ADD922700907501 /* ExpenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05F2ADD922700907501 /* ExpenseView.swift */; };
@@ -99,6 +100,7 @@
 		C179660D2ADD6BF90036E866 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		C190C2022ADAAE2C0099EE3A /* AddMemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemberView.swift; sourceTree = "<group>"; };
 		C190C20B2ADCD47E0099EE3A /* ButtonTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTheme.swift; sourceTree = "<group>"; };
+		C19AFADE2ADEAEC70037A5F5 /* CompleteAddTravelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteAddTravelView.swift; sourceTree = "<group>"; };
 		E2D5C05B2ADD921400907501 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E2D5C05D2ADD922000907501 /* DummyRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyRecordView.swift; sourceTree = "<group>"; };
 		E2D5C05F2ADD922700907501 /* ExpenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseView.swift; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 				C17550512AD54FB000A61BE5 /* TravelListView.swift */,
 				C17550532AD54FC900A61BE5 /* AddTravelView.swift */,
 				C190C2022ADAAE2C0099EE3A /* AddMemberView.swift */,
+				C19AFADE2ADEAEC70037A5F5 /* CompleteAddTravelView.swift */,
 			);
 			path = Travel;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				C190C20C2ADCD47E0099EE3A /* ButtonTheme.swift in Sources */,
 				E2D5C0622ADD923000907501 /* TodayExpenseView.swift in Sources */,
 				E2D5C0722ADD928C00907501 /* findCurrentTravel.swift in Sources */,
+				C19AFADF2ADEAEC80037A5F5 /* CompleteAddTravelView.swift in Sources */,
 				57A65D082AD7D4D100131266 /* CharacterForm.swift in Sources */,
 				E2D5C0662ADD924100907501 /* AllExpenseView.swift in Sources */,
 				E2D5C05E2ADD922000907501 /* DummyRecordView.swift in Sources */,

--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -593,7 +593,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -627,7 +627,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -346,11 +346,12 @@
 			};
 			buildConfigurationList = 571A42612ACE857500FA3D2B /* Build configuration list for PBXProject "UMM" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 571A425D2ACE857500FA3D2B;
 			productRefGroup = 571A42672ACE857500FA3D2B /* Products */;

--- a/UMM/DesignSystem/ButtonTheme.swift
+++ b/UMM/DesignSystem/ButtonTheme.swift
@@ -134,7 +134,7 @@ struct MediumButtonUnactive: View {
 
 struct NextButtonActive: View {
     
-    var title: String = "다음"
+    var title: String = ""
     var action: () -> Void
     
     var body: some View {
@@ -159,7 +159,7 @@ struct NextButtonActive: View {
 
 struct NextButtonUnactive: View {
     
-    var title: String = "다음"
+    var title: String = ""
     var action: () -> Void
     
     var body: some View {

--- a/UMM/DesignSystem/ButtonTheme.swift
+++ b/UMM/DesignSystem/ButtonTheme.swift
@@ -134,7 +134,7 @@ struct MediumButtonUnactive: View {
 
 struct NextButtonActive: View {
     
-    var title: String = ""
+    var title: String
     var action: () -> Void
     
     var body: some View {
@@ -159,7 +159,7 @@ struct NextButtonActive: View {
 
 struct NextButtonUnactive: View {
     
-    var title: String = ""
+    var title: String
     var action: () -> Void
     
     var body: some View {
@@ -243,8 +243,8 @@ struct ButtonThemeTemplate: View {
             }
 
             HStack {
-                NextButtonActive {}
-                NextButtonUnactive {}
+                NextButtonActive(title: "다음") {}
+                NextButtonUnactive(title: "다음") {}
             }
             
             HStack {

--- a/UMM/DesignSystem/ButtonTheme.swift
+++ b/UMM/DesignSystem/ButtonTheme.swift
@@ -221,8 +221,7 @@ struct DoneButtonUnactive: View {
         .background(Color.gray)
         .cornerRadius(12)
         .padding(.trailing, 16)
-        .padding(.bottom, 45)
-        
+        .padding(.bottom, 45)        
     }
 }
 

--- a/UMM/View/MainView.swift
+++ b/UMM/View/MainView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MainView: View {
     var body: some View {
-        VStack {
+        NavigationStack {
             TabView {
                 TravelListView(month: Date())
                     .tabItem {

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -13,6 +13,13 @@ struct AddMemberView: View {
             
             Text("AddMemberView")
             
+            NavigationLink(destination: CompleteAddTravelView()) {
+                NextButtonActive(title: "다음", action: {
+                    
+                })
+                .disabled(true)
+            }
+            
         }
     }
 }

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -8,22 +8,105 @@
 import SwiftUI
 
 struct AddMemberView: View {
+    
+    @Environment(\.dismiss) private var dismiss
+    @State private var isSelectedAlone = true
+    @State private var isSelectedTogether = false
+    
     var body: some View {
         VStack {
             
-            Text("AddMemberView")
+            headerView
+            
+            selectBoxView
             
             NavigationLink(destination: CompleteAddTravelView()) {
-                NextButtonActive(title: "다음", action: {
+                DoneButtonActive(title: "완료", action: {
                     
                 })
                 .disabled(true)
             }
             
         }
+        .navigationTitle("새로운 여행 생성")
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: backButton)
+    }
+    
+    private var headerView: some View {
+        VStack(alignment: .leading) {
+//            Spacer()
+            
+            Text("누구와 함께하나요?")
+                .font(.custom(FontsManager.Pretendard.semiBold, size: 24))
+            
+//            Spacer()
+            
+            Text("여행 정산을 함께 할 참여자를 설정해요.")
+                .font(.custom(FontsManager.Pretendard.medium, size: 24))
+                .foregroundStyle(Color.gray300)
+            
+//            Spacer()
+        }
+    }
+    
+    private var selectBoxView: some View {
+        VStack {
+            Button {
+                self.isSelectedAlone = true
+                self.isSelectedTogether = false
+            } label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .inset(by: 1)
+                        .stroke(isSelectedAlone ? Color.mainPink : Color.gray300, lineWidth: 2)
+                        .frame(width: 350, height: 53)
+                    
+                    HStack {
+                        Circle()
+                            .foregroundStyle(isSelectedAlone ? Color.mainPink : Color.gray300)
+                            .frame(width: 21)
+                        
+                        Text("정산이 필요 없어요")
+                            .foregroundStyle(isSelectedAlone ? Color.black : Color.gray300)
+                    }
+                }
+            }
+            
+            Button {
+                self.isSelectedTogether = true
+                self.isSelectedAlone = false
+            } label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .inset(by: 1)
+                        .stroke(isSelectedTogether ? Color.mainPink : Color.gray300, lineWidth: 2)
+                        .frame(width: 350, height: 53)
+                    
+                    HStack {
+                        Circle()
+                            .foregroundStyle(isSelectedTogether ? Color.mainPink : Color.gray300)
+                            .frame(width: 21)
+                        
+                        Text("여러 명이서 정산이 필요한 여행이에요")
+                            .foregroundStyle(isSelectedTogether ? Color.black : Color.gray300)
+                    }
+                }
+            }
+        }
+    }
+    
+    var backButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .imageScale(.large)
+                .foregroundColor(Color.black)
+        }
     }
 }
 
-#Preview {
-    AddMemberView()
-}
+// #Preview {
+//     AddMemberView()
+// }

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -12,6 +12,7 @@ struct AddMemberView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var isSelectedAlone = true
     @State private var isSelectedTogether = false
+    @State private var tempNm = ""
     @State var participantArr: [String]?
     @State private var participantCnt = 0
     
@@ -179,24 +180,38 @@ struct AddMemberView: View {
     }
     
     private var participantListView: some View {
+        // LazyVGrid 로 해서 Count에 너비를 개수로 나눈 값으로
         HStack {
             if participantCnt != 0 {
                 ForEach(0..<participantCnt, id: \.self) { index in
                     HStack {
-                        ZStack {
-                            Rectangle()
-                                .foregroundColor(.clear)
-                                .frame(width: 76, height: 30)
-                                .background(Color.gray200)
-                                .cornerRadius(15)
+//                        ZStack {
+//                            Rectangle()
+//                                .foregroundColor(.clear)
+//                                .frame(width: 76, height: 30)
+//                                .background(Color.gray200)
+//                                .cornerRadius(15)
                             
-                            Text("참여자 \(index+1)")
+                            // 텍스트 필드
+                            TextField("참여자 \(index+1)", text: $tempNm)
                                 .font(.custom(FontsManager.Pretendard.medium, size: 16))
                                 .foregroundStyle(Color.black)
+                                .textFieldStyle(CustomTextFieldStyle())
                         }
-                    }
+//                    }
                 }
             }
+        }
+    }
+    
+    struct CustomTextFieldStyle: TextFieldStyle {
+        func _body(configuration: TextField<Self._Label>) -> some View {
+            configuration
+                .padding(10)
+                .foregroundColor(.black)
+                .frame(width: 83, height: 30)
+                .background(Color(0xD9D9D9))
+                .cornerRadius(15)
         }
     }
     

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AddMemberView: View {
     var body: some View {
         VStack {
+            
             Text("AddMemberView")
             
         }

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -12,21 +12,46 @@ struct AddMemberView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var isSelectedAlone = true
     @State private var isSelectedTogether = false
+    @State var participantArr: [String]?
+    @State private var participantCnt = 0
     
     var body: some View {
         VStack {
+            
+            Spacer()
             
             headerView
             
             selectBoxView
             
-            NavigationLink(destination: CompleteAddTravelView()) {
-                DoneButtonActive(title: "완료", action: {
+            Spacer()
+            
+            isTogetherView
+            
+            Spacer()
+            
+            HStack {
+                Spacer()
+                
+                if isSelectedTogether == true && participantCnt == 0 {
+                    DoneButtonUnactive(title: "완료", action: {
+                        
+                    })
+                    .disabled(true)
                     
-                })
-                .disabled(true)
+                } else {
+                    NavigationLink(destination: CompleteAddTravelView()) {
+                        DoneButtonActive(title: "완료", action: {
+                            
+                        })
+                        .disabled(true)
+                    }
+                }
             }
             
+        }
+        .onAppear {
+            print(participantArr?.count as Any)
         }
         .navigationTitle("새로운 여행 생성")
         .navigationBarBackButtonHidden(true)
@@ -46,7 +71,7 @@ struct AddMemberView: View {
                 .font(.custom(FontsManager.Pretendard.medium, size: 24))
                 .foregroundStyle(Color.gray300)
             
-//            Spacer()
+            Spacer()
         }
     }
     
@@ -69,7 +94,11 @@ struct AddMemberView: View {
                         
                         Text("정산이 필요 없어요")
                             .foregroundStyle(isSelectedAlone ? Color.black : Color.gray300)
+                        
+                        Spacer()
                     }
+                    .padding(.leading, 10)
+                    .frame(width: 350, height: 53)
                 }
             }
             
@@ -90,6 +119,81 @@ struct AddMemberView: View {
                         
                         Text("여러 명이서 정산이 필요한 여행이에요")
                             .foregroundStyle(isSelectedTogether ? Color.black : Color.gray300)
+                        
+                        Spacer()
+                    }
+                    .padding(.leading, 10)
+                    .frame(width: 350, height: 53)
+                }
+            }
+        }
+    }
+    
+    private var isTogetherView: some View {
+        
+        VStack {
+            HStack {
+                if self.isSelectedTogether == true {
+                    HStack {
+                        ZStack {
+                            Rectangle()
+                                .foregroundColor(.clear)
+                                .frame(width: 76, height: 30)
+                                .background(Color.gray200)
+                                .cornerRadius(15)
+                            
+                            Text("me")
+                                .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                                .foregroundStyle(Color.white)
+                            +
+                            Text("나")
+                                .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                                .foregroundStyle(Color.black)
+                        }
+                        
+                        participantListView
+                        
+                        Button {
+                            participantCnt += 1
+                        } label: {
+                            ZStack {
+                                Rectangle()
+                                    .foregroundColor(.clear)
+                                    .frame(width: 44, height: 30)
+                                    .cornerRadius(15)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 15)
+                                            .inset(by: 0.5)
+                                            .stroke(.black, style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                                    )
+                                
+                                Image(systemName: "plus")
+                                    .foregroundStyle(Color.black)
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer()
+        }
+    }
+    
+    private var participantListView: some View {
+        HStack {
+            if participantCnt != 0 {
+                ForEach(0..<participantCnt, id: \.self) { index in
+                    HStack {
+                        ZStack {
+                            Rectangle()
+                                .foregroundColor(.clear)
+                                .frame(width: 76, height: 30)
+                                .background(Color.gray200)
+                                .cornerRadius(15)
+                            
+                            Text("참여자 \(index+1)")
+                                .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                                .foregroundStyle(Color.black)
+                        }
                     }
                 }
             }

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -12,7 +12,9 @@ struct AddMemberView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var isSelectedAlone = true
     @State private var isSelectedTogether = false
-    @State private var tempNm = ""
+//    @State private var tempNm = ""
+//    @State private var tempNmList: [String]?
+    @State private var tempNmList = ["", "", "", ""]
     @State var participantArr: [String]?
     @State private var participantCnt = 0
     
@@ -22,6 +24,8 @@ struct AddMemberView: View {
             Spacer()
             
             headerView
+            
+            Spacer()
             
             selectBoxView
             
@@ -61,12 +65,12 @@ struct AddMemberView: View {
     
     private var headerView: some View {
         VStack(alignment: .leading) {
-//            Spacer()
+            Spacer()
             
             Text("누구와 함께하나요?")
                 .font(.custom(FontsManager.Pretendard.semiBold, size: 24))
             
-//            Spacer()
+            Spacer()
             
             Text("여행 정산을 함께 할 참여자를 설정해요.")
                 .font(.custom(FontsManager.Pretendard.medium, size: 24))
@@ -147,7 +151,7 @@ struct AddMemberView: View {
                                 .font(.custom(FontsManager.Pretendard.medium, size: 16))
                                 .foregroundStyle(Color.white)
                             +
-                            Text("나")
+                            Text(" 나")
                                 .font(.custom(FontsManager.Pretendard.medium, size: 16))
                                 .foregroundStyle(Color.black)
                         }
@@ -156,6 +160,7 @@ struct AddMemberView: View {
                         
                         Button {
                             participantCnt += 1
+                            
                         } label: {
                             ZStack {
                                 Rectangle()
@@ -184,22 +189,18 @@ struct AddMemberView: View {
         HStack {
             if participantCnt != 0 {
                 ForEach(0..<participantCnt, id: \.self) { index in
+                    
                     HStack {
-//                        ZStack {
-//                            Rectangle()
-//                                .foregroundColor(.clear)
-//                                .frame(width: 76, height: 30)
-//                                .background(Color.gray200)
-//                                .cornerRadius(15)
-                            
-                            // 텍스트 필드
-                            TextField("참여자 \(index+1)", text: $tempNm)
-                                .font(.custom(FontsManager.Pretendard.medium, size: 16))
-                                .foregroundStyle(Color.black)
-                                .textFieldStyle(CustomTextFieldStyle())
-                        }
-//                    }
+                        
+                        TextField("참여자 \(index+1)", text: $tempNmList[index])
+                            .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                            .foregroundStyle(Color.black)
+                            .textFieldStyle(CustomTextFieldStyle())
+                    }
                 }
+                
+            } else {
+               Text("  ")
             }
         }
     }

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AddTravelView: View {
     
-    @ObservedObject private var viewModel = AddTravelViewModel(currentMonth: Date())
+    @ObservedObject private var viewModel = AddTravelViewModel(currentMonth: Date(), currentYear: Date())
     @Environment(\.dismiss) private var dismiss
     @State private var modalDate = Date()
     @State private var showStartModal = false

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -69,18 +69,20 @@ struct AddTravelView: View {
     private var headerView: some View {
         
         VStack(alignment: .leading) {
-            Spacer()
-            
-            Text("기간을 입력해주세요")
-                .font(.custom(FontsManager.Pretendard.semiBold, size: 24))
-            
-            Spacer()
-            
-            Text("여행의 시작일과 종료일을 설정해주세요.")
-                .font(.custom(FontsManager.Pretendard.medium, size: 16))
-                .foregroundStyle(Color.gray300)
-            
-            Spacer()
+            VStack(alignment: .leading) {
+                Spacer()
+                
+                Text("기간을 입력해주세요")
+                    .font(.custom(FontsManager.Pretendard.semiBold, size: 24))
+                
+                Spacer()
+                
+                Text("여행의 시작일과 종료일을 설정해주세요.")
+                    .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                    .foregroundStyle(Color.gray300)
+                
+                Spacer()
+            }
             
             HStack {
                 Text("시작일*")
@@ -264,19 +266,19 @@ struct AddTravelView: View {
     }
 
     private struct CellView: View {
-
+        
         private var day: Int
         private var date: Date?
         private var textColor: Color
         @ObservedObject private var viewModel: AddTravelViewModel
-
+        
         init(day: Int, viewModel: AddTravelViewModel, date: Date?, textColor: Color) {
             self.day = day
             self.viewModel = viewModel
             self.date = date
             self.textColor = textColor
         }
-
+        
         var body: some View {
             VStack {
                 Button {
@@ -317,7 +319,6 @@ struct AddTravelView: View {
                                         .foregroundStyle(Color.white)
                                 }
                             }
-                            
                         }
                 }
             }
@@ -339,14 +340,14 @@ struct AddTravelView: View {
     }
     
     var backButton: some View {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .imageScale(.large)
-                    .foregroundColor(Color.black)
-            }
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .imageScale(.large)
+                .foregroundColor(Color.black)
         }
+    }
 }
 
 // #Preview {

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -47,7 +47,7 @@ struct AddTravelView: View {
                 Spacer()
                 
                 if viewModel.startDate != nil {
-                    NavigationLink(destination: AddMemberView()) {
+                    NavigationLink(destination: AddMemberView(participantArr: nil)) {
                         NextButtonActive(title: "다음", action: {
                             
                         })
@@ -326,7 +326,7 @@ struct AddTravelView: View {
     }
     
     var nextButton: some View {
-        NavigationLink(destination: AddMemberView()) {
+        NavigationLink(destination: AddMemberView(participantArr: nil)) {
             ZStack {
                 Rectangle()
                     .frame(width: 134, height: 45)

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -35,7 +35,15 @@ struct AddTravelView: View {
             
             Spacer()
             
-            nextButton
+            HStack {
+                Spacer()
+                
+                NavigationLink(destination: AddMemberView()) {
+                    NextButtonActive(title: "다음", action: {
+                        print("sfdsf")
+                    })
+                }
+            }
             
             Spacer()
         }
@@ -191,7 +199,6 @@ struct AddTravelView: View {
         var body: some View {
             VStack {
                 Button {
-                    
                     let result = viewModel.startDateEndDate(in: viewModel.startDate, endDate: viewModel.endDate, selectDate: date!-1)
                     viewModel.startDate = result[0]
                     viewModel.endDate = result[1]
@@ -205,11 +212,29 @@ struct AddTravelView: View {
                         .foregroundStyle(textColor)
                         .overlay {
                             if viewModel.startDateToString(in: viewModel.startDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.startDateToString(in: self.date! - 1) {
-                                Circle()
-                                    .opacity(0.5)
-                            } else {
-                                Circle()
-                                    .opacity(0)
+                                ZStack {
+                                    
+                                    Circle()
+                                        .stroke(Color.black)
+                                        .fill(Color.mainPink)
+                                    
+                                    Text(String(day))
+                                        .padding(9.81)
+                                        .frame(width: 45, height: 41)
+                                        .foregroundStyle(Color.white)
+                                }
+                            } else if viewModel.endDateToString(in: viewModel.endDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.endDateToString(in: self.date! - 1) {
+                                ZStack {
+                                    
+                                    Circle()
+                                        .stroke(Color.black)
+                                        .fill(Color.mainPink)
+                                    
+                                    Text(String(day))
+                                        .padding(9.81)
+                                        .frame(width: 45, height: 41)
+                                        .foregroundStyle(Color.white)
+                                }
                             }
                             
                         }
@@ -229,8 +254,7 @@ struct AddTravelView: View {
                 Text("다음")
                     .foregroundStyle(Color.white)
             }
-                
-        }.disabled(!viewModel.isSelectedStartDate)
+        }
     }
     
     var backButton: some View {
@@ -244,6 +268,6 @@ struct AddTravelView: View {
         }
 }
 
-#Preview {
-    AddTravelView()
-}
+// #Preview {
+//     AddTravelView()
+// }

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -11,6 +11,9 @@ struct AddTravelView: View {
     
     @ObservedObject private var viewModel = AddTravelViewModel(currentMonth: Date())
     @Environment(\.dismiss) private var dismiss
+    @State private var modalDate = Date()
+    @State private var showStartModal = false
+    @State private var showEndModal = false
 
     var body: some View {
         VStack {
@@ -40,7 +43,7 @@ struct AddTravelView: View {
                 
                 NavigationLink(destination: AddMemberView()) {
                     NextButtonActive(title: "다음", action: {
-                        print("sfdsf")
+//                        print("sfdsf")
                     })
                 }
             }
@@ -65,36 +68,83 @@ struct AddTravelView: View {
             HStack {
                 Text("시작일*")
                 
-                ZStack {
-                    Rectangle()
-                        .foregroundColor(.clear)
-                        .frame(width: 95, height: 25)
-                        .cornerRadius(3)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 3)
-                                .inset(by: 0.5)
-                                .stroke(Color(red: 0.98, green: 0.22, blue: 0.36), lineWidth: 1)
-                        )
-                    Text(viewModel.startDateToString(in: viewModel.startDate))
+                Button {
+                    self.showStartModal = true
+                } label: {
+                    ZStack {
+                        Rectangle()
+                            .foregroundColor(.clear)
+                            .frame(width: 95, height: 25)
+                            .cornerRadius(3)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .inset(by: 0.5)
+                                    .stroke(Color(red: 0.98, green: 0.22, blue: 0.36), lineWidth: 1)
+                            )
+                        Text(viewModel.startDateToString(in: viewModel.startDate))
+                            .foregroundStyle(Color.black)
+                    }
+                }
+                .sheet(isPresented: $showStartModal) {
+                    startDatePickerModalView
+                        .presentationDetents([.height(354), .height(354)])
                 }
                 
                 Text("-")
                 
                 Text("종료일")
                 
-                ZStack {
-                    Rectangle()
-                      .foregroundColor(.clear)
-                      .frame(width: 95, height: 25)
-                      .cornerRadius(3)
-                      .overlay(
-                        RoundedRectangle(cornerRadius: 3)
-                          .inset(by: 0.5)
-                          .stroke(.black, lineWidth: 1)
-                      )
-                    Text(viewModel.endDateToString(in: viewModel.endDate))
+                Button {
+                    self.showEndModal = true
+                } label: {
+                    ZStack {
+                        Rectangle()
+                            .foregroundColor(.clear)
+                            .frame(width: 95, height: 25)
+                            .cornerRadius(3)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .inset(by: 0.5)
+                                    .stroke(Color(red: 0.98, green: 0.22, blue: 0.36), lineWidth: 1)
+                            )
+                        Text(viewModel.endDateToString(in: viewModel.endDate))
+                            .foregroundStyle(Color.black)
+                    }
                 }
-            }
+                .sheet(isPresented: $showEndModal) {
+                    endDatePickerModalView
+                        .presentationDetents([.height(354), .height(354)])
+                }            }
+        }
+    }
+
+    private var startDatePickerModalView: some View {
+        VStack {
+            DatePicker("", selection: $modalDate, displayedComponents: .date)
+                .datePickerStyle(WheelDatePickerStyle()).labelsHidden()
+           
+            LargeButtonActive(title: "확인", action: {
+                showEndModal = false
+                viewModel.startDate = modalDate
+            })
+        }
+        .onAppear {
+            modalDate = viewModel.startDate ?? Date()
+        }
+    }
+    
+    private var endDatePickerModalView: some View {
+        VStack {
+            DatePicker("", selection: $modalDate, displayedComponents: .date)
+                .datePickerStyle(WheelDatePickerStyle()).labelsHidden()
+           
+            LargeButtonActive(title: "확인", action: {
+                showEndModal = false
+                viewModel.endDate = modalDate
+            })
+        }
+        .onAppear {
+            modalDate = viewModel.endDate ?? Date()
         }
     }
 

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -25,15 +25,20 @@ struct AddTravelView: View {
             Spacer()
             
             VStack {
+                Spacer()
+                
                 calendarHeader
                 calendarGridView
+                
+                Spacer()
             }
+            .frame(width: UIScreen.main.bounds.size.width-30, height: 413)
             .padding(20)
             .overlay {
                 RoundedRectangle(cornerRadius: 21.49123)
                     .inset(by: 0.51)
-                    .stroke(Color.gray, lineWidth: 1.02)
-                    .frame(width: UIScreen.main.bounds.size.width-15, height: .none)
+                    .stroke(Color.gray200, lineWidth: 1.02)
+                    .frame(width: UIScreen.main.bounds.size.width-30, height: 413)
             }
             
             Spacer()
@@ -43,12 +48,11 @@ struct AddTravelView: View {
                 
                 NavigationLink(destination: AddMemberView()) {
                     NextButtonActive(title: "다음", action: {
-//                        print("sfdsf")
+                        
                     })
+                    .disabled(true)
                 }
             }
-            
-            Spacer()
         }
         .navigationTitle("새로운 여행 생성")
         .navigationBarBackButtonHidden(true)
@@ -56,15 +60,21 @@ struct AddTravelView: View {
     }
 
     private var headerView: some View {
-
-        VStack(alignment: .leading, spacing: 10) {
-
+        
+        VStack(alignment: .leading) {
+            Spacer()
+            
             Text("기간을 입력해주세요")
-                .font(.title)
-                .fontWeight(.bold)
-
+                .font(.custom(FontsManager.Pretendard.semiBold, size: 24))
+            
+            Spacer()
+            
             Text("여행의 시작일과 종료일을 설정해주세요.")
-
+                .font(.custom(FontsManager.Pretendard.medium, size: 16))
+                .foregroundStyle(Color.gray300)
+            
+            Spacer()
+            
             HStack {
                 Text("시작일*")
                 
@@ -72,6 +82,10 @@ struct AddTravelView: View {
                     self.showStartModal = true
                 } label: {
                     ZStack {
+                        Text(viewModel.startDateToString(in: viewModel.startDate))
+                            .font(.custom(FontsManager.Pretendard.regular, size: 14))
+                            .foregroundStyle(Color(0x6C6C6C))
+                        
                         Rectangle()
                             .foregroundColor(.clear)
                             .frame(width: 95, height: 25)
@@ -79,10 +93,9 @@ struct AddTravelView: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: 3)
                                     .inset(by: 0.5)
-                                    .stroke(Color(red: 0.98, green: 0.22, blue: 0.36), lineWidth: 1)
+                                    .stroke(Color.black, lineWidth: 1)
                             )
-                        Text(viewModel.startDateToString(in: viewModel.startDate))
-                            .foregroundStyle(Color.black)
+                        
                     }
                 }
                 .sheet(isPresented: $showStartModal) {
@@ -105,16 +118,19 @@ struct AddTravelView: View {
                             .overlay(
                                 RoundedRectangle(cornerRadius: 3)
                                     .inset(by: 0.5)
-                                    .stroke(Color(red: 0.98, green: 0.22, blue: 0.36), lineWidth: 1)
+                                    .stroke(Color.black, lineWidth: 1)
                             )
                         Text(viewModel.endDateToString(in: viewModel.endDate))
-                            .foregroundStyle(Color.black)
+                            .font(.custom(FontsManager.Pretendard.regular, size: 14))
+                            .foregroundStyle(Color(0x6C6C6C))
                     }
                 }
                 .sheet(isPresented: $showEndModal) {
                     endDatePickerModalView
                         .presentationDetents([.height(354), .height(354)])
-                }            }
+                }
+            }
+            Spacer()
         }
     }
 
@@ -124,7 +140,7 @@ struct AddTravelView: View {
                 .datePickerStyle(WheelDatePickerStyle()).labelsHidden()
            
             LargeButtonActive(title: "확인", action: {
-                showEndModal = false
+                showStartModal = false
                 viewModel.startDate = modalDate
             })
         }
@@ -161,16 +177,23 @@ struct AddTravelView: View {
                         .font(.title)
                         .foregroundStyle(Color.black)
                 }
-
+                
                 Spacer()
-
+                
+                Text(viewModel.year, formatter: AddTravelViewModel.dateYearFormatter)
+                    .font(.custom(FontsManager.Pretendard.medium, size: 20.47))
+                    .foregroundStyle(Color(0x333333))
+                +
+                Text(".")
+                    .font(.custom(FontsManager.Pretendard.medium, size: 20.47))
+                    .foregroundStyle(Color(0x333333))
+                +
                 Text(viewModel.month, formatter: AddTravelViewModel.dateFormatter)
-                    .font(.title)
-                + Text("월")
-                    .font(.title)
-
+                    .font(.custom(FontsManager.Pretendard.medium, size: 20.47))
+                    .foregroundStyle(Color(0x333333))
+                
                 Spacer()
-
+                
                 Button {
                     viewModel.changeMonth(by: 1)
                 } label: {

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -46,8 +46,15 @@ struct AddTravelView: View {
             HStack {
                 Spacer()
                 
-                NavigationLink(destination: AddMemberView()) {
-                    NextButtonActive(title: "다음", action: {
+                if viewModel.startDate != nil {
+                    NavigationLink(destination: AddMemberView()) {
+                        NextButtonActive(title: "다음", action: {
+                            
+                        })
+                        .disabled(true)
+                    }
+                } else {
+                    NextButtonUnactive(title: "다음", action: {
                         
                     })
                     .disabled(true)
@@ -130,6 +137,7 @@ struct AddTravelView: View {
                         .presentationDetents([.height(354), .height(354)])
                 }
             }
+            
             Spacer()
         }
     }

--- a/UMM/View/Travel/CompleteAddTravelView.swift
+++ b/UMM/View/Travel/CompleteAddTravelView.swift
@@ -1,0 +1,20 @@
+//
+//  CompleteAddTravelView.swift
+//  UMM
+//
+//  Created by GYURI PARK on 2023/10/17.
+//
+
+import SwiftUI
+
+struct CompleteAddTravelView: View {
+    var body: some View {
+        VStack {
+            Text("CompleteAddTravelView")
+        }
+    }
+}
+
+#Preview {
+    CompleteAddTravelView()
+}

--- a/UMM/ViewModel/AddTravelViewModel.swift
+++ b/UMM/ViewModel/AddTravelViewModel.swift
@@ -23,7 +23,7 @@ class AddTravelViewModel: ObservableObject {
     static let dateFormatter: DateFormatter = {
 
         let formatter = DateFormatter()
-        formatter.dateFormat = "M"
+        formatter.dateFormat = "MM"
 
         return formatter
     }()

--- a/UMM/ViewModel/AddTravelViewModel.swift
+++ b/UMM/ViewModel/AddTravelViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class AddTravelViewModel: ObservableObject {
 
     @Published var month: Date
+    @Published var year: Date
     @Published var prevMonth: Date
     @Published var nextMonth: Date
     @Published var startDate: Date?
@@ -23,6 +24,14 @@ class AddTravelViewModel: ObservableObject {
 
         let formatter = DateFormatter()
         formatter.dateFormat = "M"
+
+        return formatter
+    }()
+    
+    static let dateYearFormatter: DateFormatter = {
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY"
 
         return formatter
     }()
@@ -45,6 +54,7 @@ class AddTravelViewModel: ObservableObject {
 
     init(currentMonth: Date) {
         self.month = currentMonth
+        self.year = currentMonth
         self.prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth)!
         self.nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth)!
         self.startDate = nil

--- a/UMM/ViewModel/AddTravelViewModel.swift
+++ b/UMM/ViewModel/AddTravelViewModel.swift
@@ -52,9 +52,9 @@ class AddTravelViewModel: ObservableObject {
         return formatter
     }()
 
-    init(currentMonth: Date) {
+    init(currentMonth: Date, currentYear: Date) {
         self.month = currentMonth
-        self.year = currentMonth
+        self.year = currentYear
         self.prevMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth)!
         self.nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth)!
         self.startDate = nil
@@ -117,6 +117,18 @@ class AddTravelViewModel: ObservableObject {
             self.nextMonth = nextMonth
         }
     }
+    
+    // 12월 -> 1월 year + 1
+    // 1월 -> 12월 year -1
+//    func changeYear(by value: Int) {
+//        let calendar = Calendar.current
+//        
+//        if let newYear = calendar.date(byAdding: .month, value: value, to: month),
+//            let prevYear = calendar.date(byAdding: .month, value: value - 1, to: month),
+//           let nextYear= calendar.date(byAdding: .month, value: value + 1, to: month) {
+//            self.year = newYear
+//        }
+//    }
 
     func dateToDay(in date: Date) -> String {
         return AddTravelViewModel.dateToDayFormatter.string(from: date)


### PR DESCRIPTION
## 👀 이슈
- #47 
- #58 

## 💡 작업 내용
- 달력의 테두리 크기 수정
- 종료일 표시
- 시작일과 종료일을 눌렀을 때 DatePicker 추가
- AddMemberView 뷰 찍먹
- 정산 멤버 추가

## 📱스크린샷

![Simulator Screen Recording - iPhone 15 - 2023-10-18 at 00 30 00](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/83bf055d-d434-440f-82b3-d2ca09944556)

## 🚨 참고 사항

- 추가 수정 사항들은 이슈에 올려놓을 예정입니다.
- 현재 정산 멤버들 추가는 최대 4명까지로 List를 만들어놓았는데 이후 추가 예정입니다.
- 달력에 year값 반영, 여행 기간 전체 그라데이션 등등...
- 빨리 CoreDate에 값 추가 하는거 하고 싶어서 대충 그렸어요....계속 수정할게요 ~~~~~

## (Optional) 🤔 고민한 점

- 시작일과 종료일을 입력하면 자꾸 뷰가 밀린다ㅜㅜㅜㅜㅜ