### PR TITLE
⚡ [#74] 모든 ExpenseView에 화폐 단위 필터링 추가

### DIFF
--- a/UMM/View/Expense/AllExpenseDetailView.swift
+++ b/UMM/View/Expense/AllExpenseDetailView.swift
@@ -15,6 +15,7 @@ struct AllExpenseDetailView: View {
     var selectedCategory: Int64
     var selectedCountry: Int64
     @State var selectedPaymentMethod: Int64 = -1
+    @State private var currencySums : [CurrencySum] = []
     
     var body: some View {
         ScrollView {
@@ -26,6 +27,7 @@ struct AllExpenseDetailView: View {
             .pickerStyle(MenuPickerStyle())
             .onChange(of: selectedPaymentMethod) { _ in
                 expenseViewModel.filteredExpenses = getFilteredExpenses()
+                currencySums = expenseViewModel.calculateCurrencySums(from : expenseViewModel.filteredExpenses)
             }
             
             Spacer()
@@ -37,16 +39,27 @@ struct AllExpenseDetailView: View {
             expenseViewModel.fetchExpense()
             dummyRecordViewModel.fetchDummyTravel()
             expenseViewModel.selectedTravel = findCurrentTravel()
-            expenseViewModel.filteredExpenses = getFilteredExpenses()
+            
+            let filteredResult = getFilteredExpenses()
+            expenseViewModel.filteredExpenses = filteredResult
+            currencySums = expenseViewModel.calculateCurrencySums(from: expenseViewModel.filteredExpenses)
         }
     }
     
     // 최종 배열을 그리는 함수입니다.
     private var drawExpensesDetail: some View {
-        ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
-            VStack {
-                Text(expense.description)
-            }.padding()
+        VStack {
+            ForEach(currencySums , id:\.currency){ currencySum in
+                Text("\(currencySum.currency): \(currencySum.sum)")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(.bottom , 2)
+            }
+            ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
+                VStack {
+                    Text(expense.description)
+                }.padding()
+            }
         }
     }
     

--- a/UMM/View/Expense/AllExpenseDetailView.swift
+++ b/UMM/View/Expense/AllExpenseDetailView.swift
@@ -15,7 +15,7 @@ struct AllExpenseDetailView: View {
     var selectedCategory: Int64
     var selectedCountry: Int64
     @State var selectedPaymentMethod: Int64 = -1
-    @State private var currencySums : [CurrencySum] = []
+    @State private var currencySums: [CurrencySum] = []
     
     var body: some View {
         ScrollView {
@@ -25,9 +25,9 @@ struct AllExpenseDetailView: View {
                 }
             }
             .pickerStyle(MenuPickerStyle())
-            .onChange(of: selectedPaymentMethod) { _ in
+            .onChange(of: selectedPaymentMethod) {
                 expenseViewModel.filteredExpenses = getFilteredExpenses()
-                currencySums = expenseViewModel.calculateCurrencySums(from : expenseViewModel.filteredExpenses)
+                currencySums = expenseViewModel.calculateCurrencySums(from: expenseViewModel.filteredExpenses)
             }
             
             Spacer()
@@ -49,11 +49,11 @@ struct AllExpenseDetailView: View {
     // 최종 배열을 그리는 함수입니다.
     private var drawExpensesDetail: some View {
         VStack {
-            ForEach(currencySums , id:\.currency){ currencySum in
+            ForEach(currencySums, id: \.currency) { currencySum in
                 Text("\(currencySum.currency): \(currencySum.sum)")
                     .font(.subheadline)
                     .foregroundColor(.gray)
-                    .padding(.bottom , 2)
+                    .padding(.bottom, 2)
             }
             ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
                 VStack {

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -73,34 +73,47 @@ struct AllExpenseView: View {
     private var drawExpensesByCategory: some View {
         let countryArray = [Int64](Set<Int64>(expenseViewModel.groupedExpenses.keys)).sorted { $0 < $1 }
         return ForEach(countryArray, id: \.self) { country in
-            if country == expenseViewModel.selectedCountry {
-                let categoryArray = [Int64]([-1, 0, 1, 2, 3, 4, 5])
-                let expenseArray = expenseViewModel.filteredExpenses.filter { $0.country == country }
-                let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
-                let indexedSumArrayInPayAmountOrder = getPayAmountOrderedIndicesOfCategory(categoryArray: categoryArray, expenseArray: expenseArray)
-                
-                VStack {
-                    Text("나라 이름: \(country)")
-                    Text("전첵 금액 합: \(totalSum)")
-                    Text("categoryArray.count: \(categoryArray.count)")
-                    Text("countryArray.count: \(countryArray.count)")
-                }
-                
-                ForEach(0..<categoryArray.count, id: \.self) { index in
-                    NavigationLink {
-                        AllExpenseDetailView(
-                            selectedTravel: expenseViewModel.selectedTravel,
-                            selectedCategory: indexedSumArrayInPayAmountOrder[index].0,
-                            selectedCountry: country,
-                            selectedPaymentMethod: -2
-                        )
-                    } label: {
-                        VStack {
-                            Text("카테고리 이름 : \(indexedSumArrayInPayAmountOrder[index].0)")
-                            Text("카테고리별 금액 합 : \(indexedSumArrayInPayAmountOrder[index].1)")
-                        }
+            VStack {
+                if country == expenseViewModel.selectedCountry {
+                    let categoryArray = [Int64]([-1, 0, 1, 2, 3, 4, 5])
+                    let expenseArray = expenseViewModel.filteredExpenses.filter { $0.country == country }
+                    let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
+                    let indexedSumArrayInPayAmountOrder = getPayAmountOrderedIndicesOfCategory(categoryArray: categoryArray, expenseArray: expenseArray)
+                    let allCurrencySums = expenseViewModel.calculateCurrencySums(from: expenseArray)
+                    
+                    let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
+                    
+                    VStack {
+                        Text("나라 이름: \(country)")
+                        Text("전체 금액 합: \(totalSum)")
+                        Text("categoryArray.count: \(categoryArray.count)")
+                        Text("countryArray.count: \(countryArray.count)")
                     }
-                    Spacer()
+                    // 전체 기록 화폐 단위
+                    ForEach(currencies, id:\.self) { currency in
+                        let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
+                        Text("\(currency): \(sum)")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                            .padding(.bottom, 2)
+                    }
+                    
+                    ForEach(0..<categoryArray.count, id: \.self) { index in
+                        NavigationLink {
+                            AllExpenseDetailView(
+                                selectedTravel: expenseViewModel.selectedTravel,
+                                selectedCategory: indexedSumArrayInPayAmountOrder[index].0,
+                                selectedCountry: country,
+                                selectedPaymentMethod: -2
+                            )
+                        } label: {
+                            VStack {
+                                Text("카테고리 이름 : \(indexedSumArrayInPayAmountOrder[index].0)")
+                                Text("카테고리별 금액 합 : \(indexedSumArrayInPayAmountOrder[index].1)")
+                            }
+                        }
+                        Spacer()
+                    }
                 }
             }
         }

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -90,7 +90,7 @@ struct AllExpenseView: View {
                         Text("countryArray.count: \(countryArray.count)")
                     }
                     // 전체 기록 화폐 단위
-                    ForEach(currencies, id:\.self) { currency in
+                    ForEach(currencies, id: \.self) { currency in
                         let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
                         Text("\(currency): \(sum)")
                             .font(.subheadline)

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -136,9 +136,6 @@ struct AllExpenseView: View {
     private func getFilteredExpenses() -> [Expense] {
         let filteredByTravel = expenseViewModel.filterExpensesByTravel(expenses: expenseViewModel.savedExpenses, selectedTravelID: expenseViewModel.selectedTravel?.id ?? UUID())
         
-//        let filteredByCategory = expenseViewModel.filterExpensesByCategory(expenses: filteredByTravel, category: expenseViewModel.selectedCategory)
-//        print("Filtered by category: \(filteredByCategory.count)")
-
         return filteredByTravel
     }
     

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -16,7 +16,7 @@ struct TodayExpenseDetailView: View {
     var selectedDate: Date
     var selectedCountry: Int64
     @State var selectedPaymentMethod: Int64 = -1
-    @State private var currencySums : [CurrencySum] = []
+    @State private var currencySums: [CurrencySum] = []
     
     var body: some View {
         ScrollView {
@@ -26,9 +26,9 @@ struct TodayExpenseDetailView: View {
                 }
             }
             .pickerStyle(MenuPickerStyle())
-            .onChange(of: selectedPaymentMethod) { _ in
+            .onChange(of: selectedPaymentMethod) {
                 expenseViewModel.filteredExpenses = getFilteredExpenses()
-                currencySums = expenseViewModel.calculateCurrencySums(from : expenseViewModel.filteredExpenses)
+                currencySums = expenseViewModel.calculateCurrencySums(from: expenseViewModel.filteredExpenses)
             }
             
             Spacer()
@@ -50,11 +50,11 @@ struct TodayExpenseDetailView: View {
     // 국가별로 비용 항목을 분류하여 표시하는 함수입니다.
     private var drawExpensesDetail: some View {
         VStack {
-            ForEach(currencySums , id:\.currency){ currencySum in
+            ForEach(currencySums, id: \.currency) { currencySum in
                 Text("\(currencySum.currency): \(currencySum.sum)")
                     .font(.subheadline)
                     .foregroundColor(.gray)
-                    .padding(.bottom , 2)
+                    .padding(.bottom, 2)
             }
             ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
                 VStack {

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -16,8 +16,8 @@ struct TodayExpenseDetailView: View {
     var selectedDate: Date
     var selectedCountry: Int64
     @State var selectedPaymentMethod: Int64 = -1
-    var currencySums : [CurrencySum]
-
+    @State private var currencySums : [CurrencySum] = []
+    
     var body: some View {
         ScrollView {
             Picker("현재 결제 수단", selection: $selectedPaymentMethod) {
@@ -28,6 +28,7 @@ struct TodayExpenseDetailView: View {
             .pickerStyle(MenuPickerStyle())
             .onChange(of: selectedPaymentMethod) { _ in
                 expenseViewModel.filteredExpenses = getFilteredExpenses()
+                currencySums = expenseViewModel.calculateCurrencySums(from : expenseViewModel.filteredExpenses)
             }
             
             Spacer()
@@ -39,24 +40,26 @@ struct TodayExpenseDetailView: View {
             expenseViewModel.fetchExpense()
             dummyRecordViewModel.fetchDummyTravel()
             expenseViewModel.selectedTravel = findCurrentTravel()
-            expenseViewModel.filteredExpenses = getFilteredExpenses()
+            
+            let filteredResult = getFilteredExpenses()
+            expenseViewModel.filteredExpenses = filteredResult
+            currencySums = expenseViewModel.calculateCurrencySums(from: expenseViewModel.filteredExpenses)
         }
     }
     
     // 국가별로 비용 항목을 분류하여 표시하는 함수입니다.
     private var drawExpensesDetail: some View {
         VStack {
+            ForEach(currencySums , id:\.currency){ currencySum in
+                Text("\(currencySum.currency): \(currencySum.sum)")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(.bottom , 2)
+            }
             ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
                 VStack {
                     Text(expense.description)
                 }.padding()
-            }
-            
-            ForEach(currencySums , id:\.currency){ currencysum in
-                Text("\(currencysum.currency): \(currencysum.sum)")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                    .padding(.bottom , 2)
             }
         }
     }

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -16,6 +16,7 @@ struct TodayExpenseDetailView: View {
     var selectedDate: Date
     var selectedCountry: Int64
     @State var selectedPaymentMethod: Int64 = -1
+    var currencySums : [CurrencySum]
 
     var body: some View {
         ScrollView {
@@ -44,11 +45,20 @@ struct TodayExpenseDetailView: View {
     
     // 국가별로 비용 항목을 분류하여 표시하는 함수입니다.
     private var drawExpensesDetail: some View {
-      ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
-          VStack {
-              Text(expense.description)
-          }.padding()
-      }
+        VStack {
+            ForEach(expenseViewModel.filteredExpenses, id: \.id) { expense in
+                VStack {
+                    Text(expense.description)
+                }.padding()
+            }
+            
+            ForEach(currencySums , id:\.currency){ currencysum in
+                Text("\(currencysum.currency): \(currencysum.sum)")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(.bottom , 2)
+            }
+        }
     }
     
     // 최종 배열

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -81,7 +81,9 @@ struct TodayExpenseView: View {
                 let expenseArray = expenseViewModel.groupedExpenses[country] ?? []
                 let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
                 
-                let allCurrencySums = calculateCurrencySums(from: expenseArray)
+                let allCurrencySums = expenseViewModel.calculateCurrencySums(from: expenseArray)
+                
+                let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
 
                 Text("나라: \(country)").font(.title3)
                 
@@ -90,8 +92,7 @@ struct TodayExpenseView: View {
                         selectedTravel: expenseViewModel.selectedTravel,
                         selectedDate: expenseViewModel.selectedDate,
                         selectedCountry: country,
-                        selectedPaymentMethod: -2, // paymentMethod와 상관 없이 모든 expense를 보여주기 위해 임의 값을 설정
-                        currencySums: allCurrencySums
+                        selectedPaymentMethod: -2 // paymentMethod와 상관 없이 모든 expense를 보여주기 위해 임의 값을 설정
                     )
                 } label: {
                     VStack {
@@ -100,7 +101,6 @@ struct TodayExpenseView: View {
                     }
                 }
                 
-                let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
                 ForEach(currencies, id:\.self) { currency in
                     let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
                     Text("\(currency): \(sum)")
@@ -115,15 +115,14 @@ struct TodayExpenseView: View {
                         let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
                         let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + $1.payAmount }
                         
-                        let allCurrencySums = calculateCurrencySums(from: filteredExpenseArray)
+                        let allCurrencySums = expenseViewModel.calculateCurrencySums(from: filteredExpenseArray)
 
                         NavigationLink {
                             TodayExpenseDetailView(
                                 selectedTravel: expenseViewModel.selectedTravel,
                                 selectedDate: expenseViewModel.selectedDate,
                                 selectedCountry: country,
-                                selectedPaymentMethod: paymentMethod,
-                                currencySums: allCurrencySums
+                                selectedPaymentMethod: paymentMethod
                             )
                         } label:{
                             VStack{
@@ -147,18 +146,6 @@ struct TodayExpenseView: View {
                 }
             }
         }
-    }
-    
-    private func calculateCurrencySums(from expenses: [Expense]) -> [CurrencySum] {
-        var currencySums = [CurrencySum]()
-        let currencies = Array(Set(expenses.map { $0.currency })).sorted { $0 < $1 }
-
-        for currency in currencies {
-            let sum = expenses.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
-            currencySums.append(CurrencySum(currency: currency, sum: sum))
-        }
-        
-        return currencySums
     }
 
     private func getFilteredExpenses() -> [Expense] {

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -80,9 +80,6 @@ struct TodayExpenseView: View {
                 let paymentMethodArray = Array(Set((expenseViewModel.groupedExpenses[country] ?? []).map { $0.paymentMethod })).sorted { $0 < $1 }
                 let expenseArray = expenseViewModel.groupedExpenses[country] ?? []
                 let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
-                
-                let allCurrencySums = expenseViewModel.calculateCurrencySums(from: expenseArray)
-                
                 let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
 
                 Text("나라: \(country)").font(.title3)
@@ -101,7 +98,7 @@ struct TodayExpenseView: View {
                     }
                 }
                 
-                ForEach(currencies, id:\.self) { currency in
+                ForEach(currencies, id: \.self) { currency in
                     let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
                     Text("\(currency): \(sum)")
                         .font(.subheadline)
@@ -114,8 +111,6 @@ struct TodayExpenseView: View {
                     VStack {
                         let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
                         let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + $1.payAmount }
-                        
-                        let allCurrencySums = expenseViewModel.calculateCurrencySums(from: filteredExpenseArray)
 
                         NavigationLink {
                             TodayExpenseDetailView(
@@ -124,15 +119,15 @@ struct TodayExpenseView: View {
                                 selectedCountry: country,
                                 selectedPaymentMethod: paymentMethod
                             )
-                        } label:{
-                            VStack{
+                        } label: {
+                            VStack {
                                 Text("결제 수단 : \(paymentMethod)")
                                     .font(.headline)
                                     .padding(.bottom, 5)
                                 Text("금액 합 : \(sumPaymentMethod)")
                             }
                         }
-                        ForEach(currencies, id:\.self) { currency in
+                        ForEach(currencies, id: \.self) { currency in
                             let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
                             Text("\(currency): \(sum)")
                                 .font(.subheadline)
@@ -164,7 +159,6 @@ struct CurrencySum {
     let currency: Int64
     let sum: Double
 }
-
 
 #Preview {
     TodayExpenseView()

--- a/UMM/View/MainView.swift
+++ b/UMM/View/MainView.swift
@@ -15,7 +15,7 @@ struct MainView: View {
                     .tabItem {
                         Label("여행 관리", systemImage: "person.crop.circle.fill")
                     }
-                    DummyRecordView()
+                    RecordView()
                     .tabItem {
                         Label("녹음", systemImage: "mic")
                     }

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -44,10 +44,7 @@ class ExpenseViewModel: ObservableObject {
         let infos = ["여행", "쇼핑", "관광"]
         let participantArray = [["John", "Alice"], ["Bob"], ["Charlie"]]
         let payAmounts = [50.0, 1000.25, 80.0]
-//        let paymentMethods = [Int64(0), Int64(1), Int64(2), Int64(3)]
-//        let voiceRecordFiles = ["voice1.mp3", "voice2.mp3", "voice3.mp3"]
         let locations = ["서울", "도쿄", "파리", "상파울루", "바그다드", "짐바브웨"]
-        let currencies = [0, 1, 2]
         let exchangeRates = [1.0, 0.009, 1.1]
 
         let tempExpense = Expense(context: viewContext)

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -51,7 +51,7 @@ class ExpenseViewModel: ObservableObject {
         let exchangeRates = [1.0, 0.009, 1.1]
 
         let tempExpense = Expense(context: viewContext)
-        tempExpense.currency = Int64(currencies.randomElement() ?? 0)
+        tempExpense.currency = Int64(Int.random(in: -1...6))
         tempExpense.exchangeRate = exchangeRates.randomElement() ?? 0.5
         tempExpense.info = infos.randomElement()
         tempExpense.location = locations.randomElement()
@@ -59,8 +59,8 @@ class ExpenseViewModel: ObservableObject {
         tempExpense.paymentMethod = Int64(Int.random(in: -1...1))
         tempExpense.payAmount = Double(payAmounts.randomElement() ?? 300.0)
         tempExpense.payDate = Date()
-        tempExpense.category = Int64(Int.random(in: 0...5))
-        tempExpense.country = Int64(Int.random(in: 0...5))
+        tempExpense.category = Int64(Int.random(in: -1...5))
+        tempExpense.country = Int64(Int.random(in: -1...5))
         
         // 현재 선택된 여행에 추가할 수 있도록
         dummyRecordViewModel.fetchDummyTravel()

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -104,6 +104,18 @@ class ExpenseViewModel: ObservableObject {
         }
     }
     
+    func calculateCurrencySums(from expenses: [Expense]) -> [CurrencySum] {
+        var currencySums = [CurrencySum]()
+        let currencies = Array(Set(expenses.map { $0.currency })).sorted { $0 < $1 }
+
+        for currency in currencies {
+            let sum = expenses.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
+            currencySums.append(CurrencySum(currency: currency, sum: sum))
+        }
+        
+        return currencySums
+    }
+    
     // MARK: - 아직 안 씀
     func groupExpensesByLocation(expenses: [Expense], location: String) -> [String?: [Expense]] {
         return Dictionary(grouping: expenses, by: { $0.location })


### PR DESCRIPTION
## 👀 이슈
- #74 

## 💡 작업 내용
- TodayExpenseView, TodayExpenseDetailView, AllExpenseView, AllExpenseDetailView에 화폐 단위 필터링 추가

## 📱스크린샷
*용량 이슈로 추후 추가*

## 🚨 참고 사항
- 화폐 단위는 랜덤하게 부여함 (기능 명세서: 자국 화폐, 달러, 원)
- 화폐 간의 정렬을 따로 하지 않은 상태 (기능 명세서: 자국 화폐 > 달러 > 원)
- TodayExpenseView의 중복된 부분(나라: 전체 고려)을 개선하는 방법을 고민 중

## (Optional) 🤔 고민한 점
- 선택한 데이터를 그대로 넘겨줄 수 있는 TodayExpenseView와 다르게, 전체 내역만 보여주다가 항목별 내역을 보여줘야하는 AllExpenseView를 위해서, DetailView에서 직접 화폐 단위 별로 필터링 해주는 방법을 선택했습니다.

핵심 함수
```
    func calculateCurrencySums(from expenses: [Expense]) -> [CurrencySum] {
        var currencySums = [CurrencySum]()
        let currencies = Array(Set(expenses.map { $0.currency })).sorted { $0 < $1 }

        for currency in currencies {
            let sum = expenses.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
            currencySums.append(CurrencySum(currency: currency, sum: sum))
        }
        
        return currencySums
    }
```