### PR TITLE
:bug:[#70] 녹음 한 번만 되는 에러 해결

### DIFF
--- a/UMM/View/Record/RecordView.swift
+++ b/UMM/View/Record/RecordView.swift
@@ -395,19 +395,21 @@ struct RecordView: View {
                 case .second(true, nil):
                     // 녹음 시작 (지점 2: Publishing changes from within view updates 오류 발생 가능)
                     state = true
-                    viewModel.startRecordTime = CFAbsoluteTimeGetCurrent()
                     print("녹음 시작")
+                    Task {
+                        await viewModel.startRecording()
+                        viewModel.startRecordTime = CFAbsoluteTimeGetCurrent()
+                    }
                     DispatchQueue.main.async {
-                        isDetectingPress_showOnButton = true
-                        viewModel.alertView_emptyIsShown = false
-                        viewModel.alertView_shortIsShown = false
-                        viewModel.recordButtonIsFocused = true
                         do {
                             try viewModel.startSTT()
                         } catch {
                             print("error starting record: \(error.localizedDescription)")
                         }
-                        viewModel.startRecording()
+                        isDetectingPress_showOnButton = true
+                        viewModel.alertView_emptyIsShown = false
+                        viewModel.alertView_shortIsShown = false
+                        viewModel.recordButtonIsFocused = true
                     }
                 default:
                     break

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -548,13 +548,21 @@ final class RecordViewModel: ObservableObject {
     }
     
     func stopSTT() {
-        self.audioEngine.stop()
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
         audioEngine.inputNode.removeTap(onBus: 0)
-        self.recognitionRequest = nil
-        self.recognitionTask = nil
+        recognitionRequest = nil
+        recognitionTask = nil
+
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("Error deactivating audio session: \(error)")
+        }
     }
     
-    func startRecording() {
+    func startRecording() async {
         let recordingSession = AVAudioSession.sharedInstance()
         do {
             try recordingSession.setCategory(.playAndRecord, mode: .default)
@@ -583,7 +591,9 @@ final class RecordViewModel: ObservableObject {
     }
     
     func stopRecording() {
-        audioRecorder.stop()
+        if audioRecorder.isRecording {
+            audioRecorder.stop()
+        }
     }
     
     func startPlayingAudio(url: URL) {


### PR DESCRIPTION
## 👀 이슈
- #70

## 💡 작업 내용
- 녹음 버튼을 여러 번 눌러도 처음처럼 동작하도록 stopSTT() 메서드의 내용에 몇 가지를 추가했습니다. 
- 녹음 버튼을 누를 때와 뗄 때의 동작을 정리했습니다.

## 📱스크린샷
-

## 🚨 참고 사항
- 이제 앱을 끄지 않아도 음성 녹음을 여러 번 할 수 있습니다.

## 🤔 고민한 점
- startRecording()은 비동기로 넘겼습니다.
- startSTT()는 메인 스레드에 놔뒀습니다. 확실하지는 않은데, async로 바꿔서 다른 스레드로 보내보니 인식능력이 떨어져 보였습니다.
