### PR TITLE
🎨 [#75] TodayExpenseView의 gui 구현 완료

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		C19AFAE32ADFB5AE0037A5F5 /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFAE22ADFB5AE0037A5F5 /* Font+Extension.swift */; };
 		C19AFAE72ADFF1440037A5F5 /* CompleteAddTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFAE62ADFF1440037A5F5 /* CompleteAddTravelViewModel.swift */; };
 		C19AFAEA2AE00A920037A5F5 /* NavigationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFAE92AE00A920037A5F5 /* NavigationUtils.swift */; };
+		E23357A42AE2724800E17CFF /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23357A32AE2724700E17CFF /* CustomDatePicker.swift */; };
+		E23357A62AE273E700E17CFF /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23357A52AE273E700E17CFF /* NSObject+Extension.swift */; };
 		E2D5C05C2ADD921400907501 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05B2ADD921400907501 /* MainView.swift */; };
 		E2D5C05E2ADD922000907501 /* DummyRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05D2ADD922000907501 /* DummyRecordView.swift */; };
 		E2D5C0602ADD922700907501 /* ExpenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C05F2ADD922700907501 /* ExpenseView.swift */; };
@@ -113,6 +115,8 @@
 		C19AFAE22ADFB5AE0037A5F5 /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 		C19AFAE62ADFF1440037A5F5 /* CompleteAddTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteAddTravelViewModel.swift; sourceTree = "<group>"; };
 		C19AFAE92AE00A920037A5F5 /* NavigationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationUtils.swift; sourceTree = "<group>"; };
+		E23357A32AE2724700E17CFF /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
+		E23357A52AE273E700E17CFF /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		E2D5C05B2ADD921400907501 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		E2D5C05D2ADD922000907501 /* DummyRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyRecordView.swift; sourceTree = "<group>"; };
 		E2D5C05F2ADD922700907501 /* ExpenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseView.swift; sourceTree = "<group>"; };
@@ -202,6 +206,7 @@
 				C179660D2ADD6BF90036E866 /* Color+Extension.swift */,
 				57CE9C742ADE97A600EDAD11 /* Date+Extension.swift */,
 				C19AFAE22ADFB5AE0037A5F5 /* Font+Extension.swift */,
+				E23357A52AE273E700E17CFF /* NSObject+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -249,6 +254,7 @@
 				E2D5C0632ADD923800907501 /* TodayExpenseDetailView.swift */,
 				E2D5C0652ADD924100907501 /* AllExpenseView.swift */,
 				E2D5C0672ADD924800907501 /* AllExpenseDetailView.swift */,
+				E23357A32AE2724700E17CFF /* CustomDatePicker.swift */,
 			);
 			path = Expense;
 			sourceTree = "<group>";
@@ -444,9 +450,11 @@
 				578858252ADBBCB2001B82FA /* InfoClassifier.mlmodel in Sources */,
 				C19AFAEA2AE00A920037A5F5 /* NavigationUtils.swift in Sources */,
 				57EA42202ADE38EE006CA587 /* Country.swift in Sources */,
+				E23357A62AE273E700E17CFF /* NSObject+Extension.swift in Sources */,
 				57CE9C752ADE97A600EDAD11 /* Date+Extension.swift in Sources */,
 				E2D5C05C2ADD921400907501 /* MainView.swift in Sources */,
 				5760066D2ADD42FA006CD8DF /* ManualRecordView.swift in Sources */,
+				E23357A42AE2724800E17CFF /* CustomDatePicker.swift in Sources */,
 				E2D5C06F2ADD927B00907501 /* TempSave.swift in Sources */,
 				E2D5C0602ADD922700907501 /* ExpenseView.swift in Sources */,
 				C19AFAE32ADFB5AE0037A5F5 /* Font+Extension.swift in Sources */,

--- a/UMM/Extension/NSObject+Extension.swift
+++ b/UMM/Extension/NSObject+Extension.swift
@@ -1,0 +1,43 @@
+//
+//  NSObject+Extension.swift
+//  UMM
+//
+//  Created by 김태현 on 10/20/23.
+//
+
+import Foundation
+import SwiftUI
+extension NSObject {
+  func accessibilityDescendant(passing test: (Any) -> Bool) -> Any? {
+
+    if test(self) { return self }
+
+    for child in accessibilityElements ?? [] {
+      if test(child) { return child }
+      if let child = child as? NSObject, let answer = child.accessibilityDescendant(passing: test) {
+        return answer
+      }
+    }
+
+    for subview in (self as? UIView)?.subviews ?? [] {
+      if test(subview) { return subview }
+      if let answer = subview.accessibilityDescendant(passing: test) {
+        return answer
+      }
+    }
+
+    return nil
+  }
+    
+    func accessibilityDescendant(identifiedAs id: String) -> Any? {
+      return accessibilityDescendant {
+        // For reasons unknown, I cannot cast a UIView to a UIAccessibilityIdentification at runtime.
+        return ($0 as? UIView)?.accessibilityIdentifier == id
+        || ($0 as? UIAccessibilityIdentification)?.accessibilityIdentifier == id
+      }
+    }
+    
+    func buttonAccessibilityDescendant() -> Any? {
+      return accessibilityDescendant { ($0 as? NSObject)?.accessibilityTraits == .button }
+    }
+}

--- a/UMM/UMMApp.swift
+++ b/UMM/UMMApp.swift
@@ -14,6 +14,7 @@ struct UMMApp: App {
     var body: some Scene {
         WindowGroup {
             MainView()
+//            TestView()
         }
     }
 }

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -22,7 +22,6 @@ struct AllExpenseView: View {
     }
     
     var body: some View {
-        // TODO: - 최신
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
                 travelPicker
@@ -115,11 +114,11 @@ struct AllExpenseView: View {
     }
     
     private var settingView: some View {
-        Button(action: {}) {
+        Button(action: {}, label: {
             Image(systemName: "wifi")
                 .font(.system(size: 16))
                 .foregroundStyle(.gray300)
-        }
+        })
     }
     
     private var todayExpenseHeader: some View {
@@ -135,7 +134,7 @@ struct AllExpenseView: View {
         HStack(spacing: 0) {
             ForEach((TabbedItems.allCases), id: \.self) { item in
                 TabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
-                .padding(.top, 8)
+                    .padding(.top, 8)
             }
         }
         .padding(.top, 32)
@@ -237,6 +236,6 @@ struct AllExpenseView: View {
     
 }
 
-//#Preview {
-//    AllExpenseView(selectedTab: .constant(1), namespace: Namespace.ID)
-//}
+//  #Preview {
+//      AllExpenseView(selectedTab: .constant(1), namespace: Namespace.ID)
+//  }

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -133,7 +133,7 @@ struct AllExpenseView: View {
     private var tabViewButton: some View {
         HStack(spacing: 0) {
             ForEach((TabbedItems.allCases), id: \.self) { item in
-                TabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
+                ExpenseTabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
                     .padding(.top, 8)
             }
         }

--- a/UMM/View/Expense/CustomDatePicker.swift
+++ b/UMM/View/Expense/CustomDatePicker.swift
@@ -1,0 +1,59 @@
+//
+//  TestView.swift
+//  UMM
+//
+//  Created by 김태현 on 10/20/23.
+//
+
+import SwiftUI
+
+struct CustomDatePicker: View {
+    @ObservedObject var expenseViewModel: ExpenseViewModel
+    @Binding var selectedDate: Date
+    var pickerId: String
+    
+    let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy.MM.dd (E)"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter
+    }()
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: {self.expenseViewModel.selectedDate.addTimeInterval(-86400)}) {
+                Image(systemName: "chevron.left")
+            }
+            ZStack {
+                Button {
+                    expenseViewModel.triggerDatePickerPopover(pickerId: pickerId)
+                } label: {
+                    Text("\(expenseViewModel.selectedDate, formatter: dateFormatter)")
+                        .foregroundStyle(.black)
+                }
+                .padding(.horizontal, 8)
+                
+                // 안 보이게 하고 Button으로 호출
+                DatePicker("", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
+                    .labelsHidden()
+                    .accessibilityIdentifier(pickerId)
+                    .onReceive(expenseViewModel.$selectedDate) { _ in
+                        DispatchQueue.main.async {
+                            expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
+                            expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
+                        }
+                    }
+                    .opacity(0)
+            }
+            
+            Button(action:{self.selectedDate.addTimeInterval(86400)}){
+                Image(systemName:"chevron.right")
+            }
+        }
+        .border(.red)
+    }
+}
+
+//  #Preview {
+//      CustomDatePicker()
+//  }

--- a/UMM/View/Expense/CustomDatePicker.swift
+++ b/UMM/View/Expense/CustomDatePicker.swift
@@ -21,9 +21,10 @@ struct CustomDatePicker: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            Button(action: {self.expenseViewModel.selectedDate.addTimeInterval(-86400)}) {
+            Button(action: {self.expenseViewModel.selectedDate.addTimeInterval(-86400)}, label: {
                 Image(systemName: "chevron.left")
-            }
+            })
+            
             ZStack {
                 Button {
                     expenseViewModel.triggerDatePickerPopover(pickerId: pickerId)
@@ -46,9 +47,10 @@ struct CustomDatePicker: View {
                     .opacity(0)
             }
             
-            Button(action:{self.selectedDate.addTimeInterval(86400)}){
-                Image(systemName:"chevron.right")
-            }
+            Button { self.selectedDate.addTimeInterval(86400)
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
         }
         .border(.red)
     }

--- a/UMM/View/Expense/CustomDatePicker.swift
+++ b/UMM/View/Expense/CustomDatePicker.swift
@@ -52,7 +52,6 @@ struct CustomDatePicker: View {
                     Image(systemName: "chevron.right")
                 }
         }
-        .border(.red)
     }
 }
 

--- a/UMM/View/Expense/ExpenseView.swift
+++ b/UMM/View/Expense/ExpenseView.swift
@@ -19,7 +19,6 @@ struct ExpenseView: View {
                 AllExpenseView(selectedTab: $selectedTab, namespace: namespace)
                     .tag(1)
             }
-            .border(.red)
         }
     }
 }

--- a/UMM/View/Expense/ExpenseView.swift
+++ b/UMM/View/Expense/ExpenseView.swift
@@ -10,44 +10,34 @@ import SwiftUI
 struct ExpenseView: View {
     @State var selectedTab = 0
     var body: some View {
-        VStack {
-            Text("ExpenseView")
-            ZStack {
-                HStack {
-                    ForEach((TabbedItems.allCases), id: \.self) {item in
-                        Button {
-                            selectedTab = item.rawValue
-                        } label: {
-                            customTabItem(title: item.title, isActive: (selectedTab == item.rawValue))
-                        }
-                    }
+        NavigationStack {
+            VStack {
+                TabView(selection: $selectedTab) {
+                    TodayExpenseView(selectedTab: $selectedTab)
+                        .tag(0)
+                    AllExpenseView(selectedTab: $selectedTab)
+                        .tag(1)
                 }
-            }
-            Spacer()
-            TabView(selection: $selectedTab) {
-                TodayExpenseView()
-                    .tag(0)
-                AllExpenseView()
-                    .tag(1)
+                .border(.red)
             }
         }
     }
 }
 
-private func customTabItem(title: String, isActive: Bool) -> some View {
+func customTabItem(title: String, isActive: Bool) -> some View {
     HStack(spacing: 10) {
         Spacer()
         Text(title)
-            .font(.system(size: 14))
-            .foregroundStyle(isActive ? .black : .gray)
+            .font(.subhead3_1)
+            .foregroundStyle(.black)
         Spacer()
     }
-    .frame(width: 80, height: 40)
 }
 
 enum TabbedItems: Int, CaseIterable {
     case todayExpense
     case allExpense
+    
     var title: String {
         switch self {
         case .todayExpense:
@@ -59,5 +49,5 @@ enum TabbedItems: Int, CaseIterable {
 }
 
 #Preview {
-    ExpenseView()
+   ExpenseView()
 }

--- a/UMM/View/Expense/ExpenseView.swift
+++ b/UMM/View/Expense/ExpenseView.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct ExpenseView: View {
     @State var selectedTab = 0
+    @Namespace var namespace
+    
     var body: some View {
         NavigationStack {
             TabView(selection: $selectedTab) {
-                TodayExpenseView(selectedTab: $selectedTab)
+                TodayExpenseView(selectedTab: $selectedTab, namespace: namespace)
                     .tag(0)
-                AllExpenseView(selectedTab: $selectedTab)
+                AllExpenseView(selectedTab: $selectedTab, namespace: namespace)
                     .tag(1)
             }
             .border(.red)
@@ -22,13 +24,43 @@ struct ExpenseView: View {
     }
 }
 
-func customTabItem(title: String, isActive: Bool) -> some View {
-    HStack(spacing: 10) {
-        Spacer()
-        Text(title)
-            .font(.subhead3_1)
-            .foregroundStyle(.black)
-        Spacer()
+struct TabBarItem: View {
+    @Binding var selectedTab: Int
+    let namespace: Namespace.ID
+    
+    var title: String
+    var tab: Int
+    
+    var body: some View {
+        Button {
+            selectedTab = tab
+        } label: {
+            VStack {
+                Text(title)
+                    .font(.subhead3_1)
+                    .foregroundStyle(selectedTab == tab ? .black : .gray300)
+
+                ZStack {
+                    Divider()
+                        .padding(.top, 12)
+                        .frame(height: 2)
+                    if selectedTab == tab {
+                        Color.black
+                            .frame(height: 2)
+                            .matchedGeometryEffect(id: "underline", in: namespace.self)
+                            .padding(.top, 11)
+                            .padding(.horizontal)
+                    } else {
+                        Color.gray300
+                            .frame(height: 2)
+                            .padding(.top, 11)
+                            .padding(.horizontal)
+                    }
+                }
+            }
+            .animation(.spring(), value: selectedTab)
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/UMM/View/Expense/ExpenseView.swift
+++ b/UMM/View/Expense/ExpenseView.swift
@@ -23,7 +23,7 @@ struct ExpenseView: View {
     }
 }
 
-struct TabBarItem: View {
+struct ExpenseTabBarItem: View {
     @Binding var selectedTab: Int
     let namespace: Namespace.ID
     

--- a/UMM/View/Expense/ExpenseView.swift
+++ b/UMM/View/Expense/ExpenseView.swift
@@ -11,15 +11,13 @@ struct ExpenseView: View {
     @State var selectedTab = 0
     var body: some View {
         NavigationStack {
-            VStack {
-                TabView(selection: $selectedTab) {
-                    TodayExpenseView(selectedTab: $selectedTab)
-                        .tag(0)
-                    AllExpenseView(selectedTab: $selectedTab)
-                        .tag(1)
-                }
-                .border(.red)
+            TabView(selection: $selectedTab) {
+                TodayExpenseView(selectedTab: $selectedTab)
+                    .tag(0)
+                AllExpenseView(selectedTab: $selectedTab)
+                    .tag(1)
             }
+            .border(.red)
         }
     }
 }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -10,108 +10,191 @@ import SwiftUI
 struct TodayExpenseView: View {
     @ObservedObject var expenseViewModel: ExpenseViewModel
     @ObservedObject var dummyRecordViewModel: DummyRecordViewModel
+    @Binding var selectedTab: Int
     
-    init() {
+    init(selectedTab: Binding<Int>) {
         self.expenseViewModel = ExpenseViewModel()
         self.dummyRecordViewModel = DummyRecordViewModel()
+        self._selectedTab = selectedTab
     }
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                Text("일별 지출")
-                
-                // Picker: 여행별
-                Picker("현재 여행", selection: $expenseViewModel.selectedTravel) {
-                    ForEach(dummyRecordViewModel.savedTravels, id: \.self) { travel in
-                        Text(travel.name ?? "no name").tag(travel as Travel?) // travel의 id가 선택지로
-                    }
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 0) {
+                    travelPicker
+                    Spacer()
+                    settingView
                 }
-                .pickerStyle(MenuPickerStyle())
-                .onReceive(expenseViewModel.$selectedTravel) { _ in
-                    DispatchQueue.main.async {
-                        expenseViewModel.filteredExpenses = getFilteredExpenses()
-                        expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
-                        print("TodayExpenseView | onReceive | done")
-                    }
-                }
-                
-                // Picker: 날짜별
-                DatePicker("날짜", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
-                    .onReceive(expenseViewModel.$selectedDate) { _ in
-                        DispatchQueue.main.async {
-                            expenseViewModel.filteredExpenses = getFilteredExpenses()
-                            expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
-                        }
-                    }
-                
-                Button {
-                    expenseViewModel.addExpense(travel: expenseViewModel.selectedTravel ?? Travel(context: dummyRecordViewModel.viewContext))
-                    DispatchQueue.main.async {
-                        expenseViewModel.filteredExpenses = getFilteredExpenses()
-                        expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
-                    }
-                } label: {
-                    Text("지출 추가")
-                }
-                
-                Spacer()
-                
-                drawExpensesByCountry
+                todayExpenseHeader
+                tabViewButton
+                datePicker
+                drawExpensesByCountry // 결제 데이터 그리기: 국가 > 결제수단 순서로 분류
+                // dummyExpenseAddButton
             }
         }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
         .onAppear {
-            print("TodayExpenseView Appeared")
             expenseViewModel.fetchExpense()
             dummyRecordViewModel.fetchDummyTravel()
             expenseViewModel.selectedTravel = findCurrentTravel()
             
-            expenseViewModel.filteredExpenses = getFilteredExpenses()
+            expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
             expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
+        }
+    }
+    
+    private var travelChoiceView: some View {
+        Button {
+            expenseViewModel.travelChoiceHalfModalIsShown = true
+            print("expenseViewModel.travelChoiceHalfModalIsShown = true")
+        } label: {
+            ZStack {
+                Capsule()
+                    .foregroundStyle(.white)
+                    .layoutPriority(-1)
+                
+                Capsule()
+                    .strokeBorder(.mainPink, lineWidth: 1.0)
+                    .layoutPriority(-1)
+                
+                HStack(spacing: 12) {
+                    Text(expenseViewModel.selectedTravel?.name != "Default" ? expenseViewModel.selectedTravel?.name ?? "-" : "-")
+                        .font(.subhead2_2)
+                        .foregroundStyle(.black)
+                    Image("recordTravelChoiceDownChevron")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 16, height: 16)
+                }
+                .padding(.vertical, 6)
+                .padding(.leading, 16)
+                .padding(.trailing, 12)
+            }
+        }
+        .padding(.top, 80)
+    }
+    
+    private var travelPicker: some View {
+        Picker("현재 여행", selection: $expenseViewModel.selectedTravel) {
+            ForEach(dummyRecordViewModel.savedTravels, id: \.self) { travel in
+                Text(travel.name ?? "no name").tag(travel as Travel?) // travel의 id가 선택지로
+            }
+        }
+        .pickerStyle(MenuPickerStyle())
+        .onReceive(expenseViewModel.$selectedTravel) { _ in
+            DispatchQueue.main.async {
+                expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
+                expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
+                print("TodayExpenseView | onReceive | done")
+            }
+        }
+    }
+    
+    private var settingView: some View {
+        Button(action: {}) {
+            Image(systemName: "wifi")
+                .font(.system(size: 16))
+                .foregroundStyle(.gray300)
+        }
+    }
+    
+    private var todayExpenseHeader: some View {
+        HStack(spacing: 0) {
+            Text("지출 관리")
+                .font(.display2)
+                .padding(.top, 12)
+            Spacer()
+        }
+    }
+    
+    private var tabViewButton: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach((TabbedItems.allCases), id: \.self) {item in
+                    Button {
+                        selectedTab = item.rawValue
+                    } label: {
+                        customTabItem(title: item.title, isActive: (selectedTab == item.rawValue))
+                    }
+                    .padding(.top, 8)
+                }
+            }
+            Divider()
+                .padding(.top, 11)
+        }
+        .padding(.top, 32)
+    }
+    
+    private var datePicker: some View {
+        DatePicker("날짜", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
+            .onReceive(expenseViewModel.$selectedDate) { _ in
+                DispatchQueue.main.async {
+                    expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
+                    expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
+                }
+            }
+            .padding(.top, 16)
+    }
+    
+    private var dummyExpenseAddButton: some View {
+        Button {
+            expenseViewModel.addExpense(travel: expenseViewModel.selectedTravel ?? Travel(context: dummyRecordViewModel.viewContext))
+            DispatchQueue.main.async {
+                expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
+                expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
+            }
+        } label: {
+            Text("지출 추가")
         }
     }
     
     // 국가별 + 결제수단별 지출액 표시
     private var drawExpensesByCountry: some View {
         let countryArray = [Int64](Set<Int64>(expenseViewModel.groupedExpenses.keys)).sorted { $0 < $1 }
-        
         return ForEach(countryArray, id: \.self) { country in
-            VStack {
-                let paymentMethodArray = Array(Set((expenseViewModel.groupedExpenses[country] ?? []).map { $0.paymentMethod })).sorted { $0 < $1 }
-                let expenseArray = expenseViewModel.groupedExpenses[country] ?? []
-                let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
-                let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
-
-                Text("나라: \(country)").font(.title3)
-                
-                NavigationLink {
-                    TodayExpenseDetailView(
-                        selectedTravel: expenseViewModel.selectedTravel,
-                        selectedDate: expenseViewModel.selectedDate,
-                        selectedCountry: country,
-                        selectedPaymentMethod: -2 // paymentMethod와 상관 없이 모든 expense를 보여주기 위해 임의 값을 설정
-                    )
-                } label: {
-                    VStack {
-                        Text("결제 수단: all")
-                        Text("금액 합: \(totalSum)")
+            let paymentMethodArray = Array(Set((expenseViewModel.groupedExpenses[country] ?? []).map { $0.paymentMethod })).sorted { $0 < $1 }
+            let expenseArray = expenseViewModel.groupedExpenses[country] ?? []
+            let totalSum = expenseArray.reduce(0) { $0 + $1.payAmount }
+            let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
+            
+            VStack(alignment: .leading, spacing: 0) {
+                // 국기 + 국가명
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(spacing: 0) {
+                        Text("국기: \(country)").font(.subhead3_1)
+                        Text("나라: \(country)").font(.subhead3_1)
+                    }
+                    
+                    // 결제 수단: 전체: 합계
+                    NavigationLink {
+                        TodayExpenseDetailView(
+                            selectedTravel: expenseViewModel.selectedTravel,
+                            selectedDate: expenseViewModel.selectedDate,
+                            selectedCountry: country,
+                            selectedPaymentMethod: -2 // paymentMethod와 상관 없이 모든 expense를 보여주기 위해 임의 값을 설정
+                        )
+                    } label: {
+                        HStack(spacing: 0) {
+                            Text("금액 합: \(expenseViewModel.formatSum(totalSum))")
+                                .font(.display3)
+                                .foregroundStyle(.black)
+                            Image(systemName: "wifi")
+                                .font(.system(size: 16))
+                                .padding(.leading, 16)
+                                .foregroundStyle(.gray300)
+                        }
                     }
                 }
+                .padding(.bottom, 16)
                 
-                ForEach(currencies, id: \.self) { currency in
-                    let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
-                    Text("\(currency): \(sum)")
-                        .font(.subheadline)
-                        .foregroundColor(.gray)
-                        .padding(.bottom, 2)
-                }
-                
-                // 결제 수단 별 합계
+                // 결제 수단: 개별: 합계
                 ForEach(paymentMethodArray, id: \.self) { paymentMethod in
-                    VStack {
+                    VStack(alignment: .leading, spacing: 0) {
                         let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
                         let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + $1.payAmount }
-
+                        
                         NavigationLink {
                             TodayExpenseDetailView(
                                 selectedTravel: expenseViewModel.selectedTravel,
@@ -120,39 +203,43 @@ struct TodayExpenseView: View {
                                 selectedPaymentMethod: paymentMethod
                             )
                         } label: {
-                            VStack {
-                                Text("결제 수단 : \(paymentMethod)")
-                                    .font(.headline)
-                                    .padding(.bottom, 5)
-                                Text("금액 합 : \(sumPaymentMethod)")
+                            HStack(alignment: .center, spacing: 0) {
+                                VStack(alignment: .leading, spacing: 0) {
+                                    HStack(spacing: 0) {
+                                        Text("결제 수단 : \(paymentMethod)")
+                                            .font(.subhead2_1)
+                                            .foregroundStyle(.gray300)
+                                    }
+                                    // 결제 수단: 개별, 화폐: 개별: 합계
+                                    HStack(spacing: 0) {
+                                        ForEach(currencies, id: \.self) { currency in
+                                            let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
+                                            Text("\(currency): \(expenseViewModel.formatSum(sum))")
+                                                .font(.subhead3_1)
+                                                .foregroundStyle(.black)
+                                        }
+                                    }
+                                    .padding(.top, 12)
+                                }
+                                Spacer()
+                                Image(systemName: "wifi")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(.gray300)
                             }
+                            .padding(16)
+                            .frame(maxWidth: .infinity)
+                            .background(Color.gray100)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .padding(.bottom, 10)
                         }
-                        ForEach(currencies, id: \.self) { currency in
-                            let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
-                            Text("\(currency): \(sum)")
-                                .font(.subheadline)
-                                .foregroundColor(.gray)
-                                .padding(.bottom, 2)
-                        }
-                        
                     }
-                    
-                    Spacer()
                 }
             }
+            .padding(.top, 20)
+            .padding(.bottom, 10)
+            .border(.red)
         }
     }
-
-    private func getFilteredExpenses() -> [Expense] {
-        let filteredByTravel = expenseViewModel.filterExpensesByTravel(expenses: expenseViewModel.savedExpenses, selectedTravelID: expenseViewModel.selectedTravel?.id ?? UUID())
-        print("Filtered by travel: \(filteredByTravel.count)")
-        
-        let filteredByDate = expenseViewModel.filterExpensesByDate(expenses: filteredByTravel, selectedDate: expenseViewModel.selectedDate)
-        print("Filtered by date: \(filteredByDate.count)")
-        
-        return filteredByDate
-    }
-    
 }
 
 struct CurrencySum {
@@ -161,5 +248,5 @@ struct CurrencySum {
 }
 
 #Preview {
-    TodayExpenseView()
+    TodayExpenseView(selectedTab: .constant(0))
 }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -239,7 +239,6 @@ struct TodayExpenseView: View {
             }
             .padding(.top, 20)
             .padding(.bottom, 10)
-            .border(.red)
         }
     } // draw
 }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -19,18 +19,20 @@ struct TodayExpenseView: View {
     }
     
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: 0) {
-                    travelPicker
-                    Spacer()
-                    settingView
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                travelPicker
+                Spacer()
+                settingView
+            }
+            todayExpenseHeader
+            tabViewButton
+            datePicker
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    drawExpensesByCountry // 결제 데이터 그리기: 국가 > 결제수단 순서로 분류
+                    // dummyExpenseAddButton
                 }
-                todayExpenseHeader
-                tabViewButton
-                datePicker
-                drawExpensesByCountry // 결제 데이터 그리기: 국가 > 결제수단 순서로 분류
-                // dummyExpenseAddButton
             }
         }
         .frame(maxWidth: .infinity)
@@ -136,6 +138,7 @@ struct TodayExpenseView: View {
                 }
             }
             .padding(.top, 16)
+            .padding(.bottom, 20)
     }
     
     private var dummyExpenseAddButton: some View {
@@ -212,11 +215,20 @@ struct TodayExpenseView: View {
                                     }
                                     // 결제 수단: 개별, 화폐: 개별: 합계
                                     HStack(spacing: 0) {
-                                        ForEach(currencies, id: \.self) { currency in
+                                        ForEach(currencies.indices, id: \.self) { index in
+                                            let currency = currencies[index]
                                             let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + $1.payAmount }
+                                            
                                             Text("\(currency): \(expenseViewModel.formatSum(sum))")
                                                 .font(.subhead3_1)
                                                 .foregroundStyle(.black)
+                                            
+                                            if index != currencies.count - 1 {
+                                                Divider()
+                                                    .font(.subhead2_1)
+                                                    .foregroundStyle(.gray200)
+                                                    .padding(.horizontal, 5)
+                                            }
                                         }
                                     }
                                     .padding(.top, 12)

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -98,11 +98,11 @@ struct TodayExpenseView: View {
     }
     
     private var settingView: some View {
-        Button(action: {}) {
+        Button(action: {}, label: {
             Image(systemName: "wifi")
                 .font(.system(size: 16))
                 .foregroundStyle(.gray300)
-        }
+        })
     }
     
     private var todayExpenseHeader: some View {
@@ -186,7 +186,7 @@ struct TodayExpenseView: View {
                 ForEach(paymentMethodArray, id: \.self) { paymentMethod in
                     VStack(alignment: .leading, spacing: 0) {
                         let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
-                        let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + $1.payAmount }
+                        // let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + $1.payAmount }
                         
                         NavigationLink {
                             TodayExpenseDetailView(
@@ -248,5 +248,3 @@ struct CurrencySum {
     let currency: Int64
     let sum: Double
 }
-
-//2

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -11,11 +11,13 @@ struct TodayExpenseView: View {
     @ObservedObject var expenseViewModel: ExpenseViewModel
     @ObservedObject var dummyRecordViewModel: DummyRecordViewModel
     @Binding var selectedTab: Int
+    let namespace: Namespace.ID
     
-    init(selectedTab: Binding<Int>) {
+    init(selectedTab: Binding<Int>, namespace: Namespace.ID) {
         self.expenseViewModel = ExpenseViewModel()
         self.dummyRecordViewModel = DummyRecordViewModel()
         self._selectedTab = selectedTab
+        self.namespace = namespace
     }
     
     var body: some View {
@@ -112,23 +114,15 @@ struct TodayExpenseView: View {
     }
     
     private var tabViewButton: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                ForEach((TabbedItems.allCases), id: \.self) {item in
-                    Button {
-                        selectedTab = item.rawValue
-                    } label: {
-                        customTabItem(title: item.title, isActive: (selectedTab == item.rawValue))
-                    }
-                    .padding(.top, 8)
-                }
+        HStack(spacing: 0) {
+            ForEach((TabbedItems.allCases), id: \.self) { item in
+                TabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
+                .padding(.top, 8)
             }
-            Divider()
-                .padding(.top, 11)
         }
         .padding(.top, 32)
     }
-    
+
     private var datePicker: some View {
         DatePicker("날짜", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
             .onReceive(expenseViewModel.$selectedDate) { _ in
@@ -188,6 +182,7 @@ struct TodayExpenseView: View {
                                 .padding(.leading, 16)
                                 .foregroundStyle(.gray300)
                         }
+                        .padding(.top, 8)
                     }
                 }
                 .padding(.bottom, 16)
@@ -259,6 +254,4 @@ struct CurrencySum {
     let sum: Double
 }
 
-#Preview {
-    TodayExpenseView(selectedTab: .constant(0))
-}
+//2

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -117,7 +117,7 @@ struct TodayExpenseView: View {
     private var tabViewButton: some View {
         HStack(spacing: 0) {
             ForEach((TabbedItems.allCases), id: \.self) { item in
-                TabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
+                ExpenseTabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
                     .padding(.top, 8)
             }
         }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -12,6 +12,7 @@ struct TodayExpenseView: View {
     @ObservedObject var dummyRecordViewModel: DummyRecordViewModel
     @Binding var selectedTab: Int
     let namespace: Namespace.ID
+    var pickerId: String { "picker" }
     
     init(selectedTab: Binding<Int>, namespace: Namespace.ID) {
         self.expenseViewModel = ExpenseViewModel()
@@ -117,20 +118,14 @@ struct TodayExpenseView: View {
         HStack(spacing: 0) {
             ForEach((TabbedItems.allCases), id: \.self) { item in
                 TabBarItem(selectedTab: $selectedTab, namespace: namespace, title: item.title, tab: item.rawValue)
-                .padding(.top, 8)
+                    .padding(.top, 8)
             }
         }
         .padding(.top, 32)
     }
-
+    
     private var datePicker: some View {
-        DatePicker("날짜", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
-            .onReceive(expenseViewModel.$selectedDate) { _ in
-                DispatchQueue.main.async {
-                    expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
-                    expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
-                }
-            }
+        CustomDatePicker(expenseViewModel: expenseViewModel, selectedDate: $expenseViewModel.selectedDate, pickerId: pickerId)
             .padding(.top, 16)
             .padding(.bottom, 20)
     }
@@ -246,7 +241,7 @@ struct TodayExpenseView: View {
             .padding(.bottom, 10)
             .border(.red)
         }
-    }
+    } // draw
 }
 
 struct CurrencySum {

--- a/UMM/View/MainView.swift
+++ b/UMM/View/MainView.swift
@@ -15,7 +15,7 @@ struct MainView: View {
                     .tabItem {
                         Label("여행 관리", systemImage: "person.crop.circle.fill")
                     }
-                    RecordView()
+                RecordView()
                     .tabItem {
                         Label("녹음", systemImage: "mic")
                     }

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import SwiftUI
 
 class ExpenseViewModel: ObservableObject {
     let viewContext = PersistenceController.shared.container.viewContext
@@ -138,5 +139,17 @@ class ExpenseViewModel: ObservableObject {
         let filteredByTravel = filterExpensesByTravel(expenses: savedExpenses, selectedTravelID: selectedTravel?.id ?? UUID())
         let filteredByDate = filterExpensesByDate(expenses: filteredByTravel, selectedDate: selectedDate)
         return filteredByDate
+    }
+    
+    // MARK: - 커스텀 Date Picker를 위한 함수
+    func triggerDatePickerPopover(pickerId: String) {
+        if
+            let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            let window = scene.windows.first,
+            let picker = window.accessibilityDescendant(identifiedAs: pickerId) as? NSObject,
+            let button = picker.buttonAccessibilityDescendant() as? NSObject
+        {
+            button.accessibilityActivate()
+        }
     }
 }

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -26,12 +26,8 @@ class ExpenseViewModel: ObservableObject {
     @Published var travelChoiceHalfModalIsShown = false {
         willSet {
             if newValue {
-                do {
-                    filteredExpenses = getFilteredExpenses()
-                    groupedExpenses = Dictionary(grouping: filteredExpenses, by: { $0.country })
-                } catch {
-                    print("error fetching travelArray: \(error.localizedDescription)")
-                }
+                filteredExpenses = getFilteredExpenses()
+                groupedExpenses = Dictionary(grouping: filteredExpenses, by: { $0.country })
             }
         }
     }


### PR DESCRIPTION
## 👀 이슈
- #75 

## 💡 작업 내용
- TodayExpenseView의 gui 구현 완료
- custom datePicker 적용
- custom tabBarItem 적용

## 📱스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-10-20 at 18 33 40](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/102353544/ca1dfef2-b017-4140-ac77-6c9d7acf8e9e)


## 🚨 참고 사항
- 미적용: enum을 실제 값으로 보이게
- 미적용: 올리버의 Travel Modal
- 미적용: 아이콘 이미지

## (Optional) 🤔 고민한 점
DatePicker의 버튼을 커스텀 하되, 기본 DatePicker의 pop over가 나오게 하고자 했습니다.
다른 함수로 DatePicker를 호출하려고 했으나, 기본적으로 제공되지 않아 StackOverFlow를 참고했습니다.

```
// 호출하는 함수
    func triggerDatePickerPopover(pickerId: String) {
        if
            let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let window = scene.windows.first,
            let picker = window.accessibilityDescendant(identifiedAs: pickerId) as? NSObject,
            let button = picker.buttonAccessibilityDescendant() as? NSObject
        {
            button.accessibilityActivate()
        }
    }
```

```
// DatePicker 호출 부분
ZStack {
    Button {
        expenseViewModel.triggerDatePickerPopover(pickerId: pickerId)
    } label: {
        Text("\(expenseViewModel.selectedDate, formatter: dateFormatter)")
            .foregroundStyle(.black)
    }
    .padding(.horizontal, 8)
    
    // 안 보이게 하고 Button으로 호출
    DatePicker("", selection: $expenseViewModel.selectedDate, displayedComponents: [.date])
        .labelsHidden()
        .accessibilityIdentifier(pickerId)
        .onReceive(expenseViewModel.$selectedDate) { _ in
            DispatchQueue.main.async {
                expenseViewModel.filteredExpenses = expenseViewModel.getFilteredExpenses()
                expenseViewModel.groupedExpenses = Dictionary(grouping: expenseViewModel.filteredExpenses, by: { $0.country })
            }
        }
        .opacity(0)
}
 ```
 
 링크: https://stackoverflow.com/questions/75073023/how-to-trigger-swiftui-datepicker-programmatically