### PR TITLE
⚡️[#91][#118][#119] 임시기록 뷰를 만들고 TravelListView의 디테일 수정 및 AddMemberView의 오류를 수정합니다.

### DIFF
--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -20,7 +20,7 @@ struct AddMemberView: View {
     @Binding var startDate: Date?
     @Binding var endDate: Date?
     @State private var participantCnt = 0
-    
+    @State private var isBackButton = false
     @State var isDisappear = false
     
     var body: some View {
@@ -40,41 +40,31 @@ struct AddMemberView: View {
             
         }
         .onAppear {
-            print("addMemberview")
+            isBackButton = false
         }
         .onDisappear {
-            if participantArr.count > 0 {
-                participantCnt -= 1
-                let updateArr = Array(participantArr.dropLast())
-                viewModel.participantArr = updateArr
-            } else {
-                viewModel.participantArr = participantArr
-            }
-            viewModel.startDate = startDate
-            viewModel.endDate = endDate
-            if let arr = viewModel.participantArr {
-                if arr.count > 0 {
-                    viewModel.travelName = arr[0] + "외 \(participantCnt)명"
+            if !isBackButton {
+                if participantArr.count > 0 {
+                    participantCnt -= 1
+                    let updateArr = Array(participantArr.dropLast())
+                    viewModel.participantArr = updateArr
                 } else {
-                    viewModel.travelName = "나의 여행"
+                    viewModel.participantArr = participantArr
                 }
+                viewModel.startDate = startDate
+                viewModel.endDate = endDate
+                if let arr = viewModel.participantArr {
+                    if arr.count > 0 {
+                        viewModel.travelName = arr[0] + "외 \(participantCnt)명"
+                    } else {
+                        viewModel.travelName = "나의 여행"
+                    }
+                }
+                viewModel.travelID = travelID
+                viewModel.addTravel()
+                viewModel.saveTravel()
+                isDisappear = true
             }
-            viewModel.travelID = travelID
-            print("addmemberview| not stop before add")
-            viewModel.addTravel()
-//            viewModel. saveTravel()
-            isDisappear = true
-            print("onDisappear")
-//            print("memeber view TravelID", travelID)
-            
-            // 저장 Test 코드
-//            var fetchedTravel: Travel?
-//            do {
-//                fetchedTravel = try PersistenceController.shared.container.viewContext.fetch(Travel.fetchRequest()).filter { $0.id == viewModel.travelID }.first
-//            } catch {
-//                print("err: \(error.localizedDescription)")
-//            }
-//            print("fetchedTravel.name: \(fetchedTravel?.id ?? UUID())")
         }
         .navigationTitle("새로운 여행 생성")
         .navigationBarBackButtonHidden(true)
@@ -260,7 +250,7 @@ struct AddMemberView: View {
             } else {
                 NavigationLink(destination: CompleteAddTravelView(addViewModel: addViewModel, travelID: $travelID, travelNM: travelName ?? "nil", isDisappear: $isDisappear)) {
                     DoneButtonActive(title: "완료", action: {
-                    
+                        isBackButton = false
                     })
                     .disabled(true)
                 }
@@ -270,6 +260,7 @@ struct AddMemberView: View {
     
     var backButton: some View {
         Button {
+            isBackButton = true
             dismiss()
         } label: {
             Image(systemName: "chevron.left")

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -312,6 +312,9 @@ struct AddTravelView: View {
                             .disabled(true)
                     }
                 }
+                .onChange(of: viewModel.endDate) {
+                    print("onChange")
+                }
             }
             .padding(.horizontal, 18)
         }
@@ -344,31 +347,30 @@ struct AddTravelView: View {
                     Text(String(day))
                         .padding(9.81)
                         .font(.calendar2)
-                        .frame(width: 45, height: 41)
+                        .frame(width: 45)
+//                        .background(Color.red)
                         .foregroundStyle(textColor)
                         .overlay {
                             if viewModel.startDateToString(in: viewModel.startDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.startDateToString(in: self.date! - 1) {
                                 ZStack {
-                                    
                                     ZStack {
-                                        
-//                                        Rectangle()
-//                                            .frame(width: 80, height: 33)
-//                                            .foregroundStyle(
-//                                                    LinearGradient(
-//                                                        gradient: Gradient(colors: [Color.mainPink.opacity(1), Color.mainPink.opacity(0)]),
-//                                                        startPoint: .leading,
-//                                                        endPoint: .trailing
-//                                                    )
-//                                                )
-//                                            .offset(x: 40)
+                                        Rectangle()
+                                            .frame(width: 80, height: 33)
+                                            .foregroundStyle(
+                                                LinearGradient(
+                                                    gradient: Gradient(colors: [Color.mainPink.opacity(1), Color.mainPink.opacity(0)]),
+                                                    startPoint: .leading,
+                                                    endPoint: .trailing
+                                                )
+                                            )
+                                            .offset(x: 40)
                                         
                                         Circle()
                                             .frame(width: 33, height: 33)
                                             .overlay(
-                                            Circle()
-                                                .stroke(Color.white)
-                                                .fill(Color.mainPink)
+                                                Circle()
+                                                    .stroke(Color.white)
+                                                    .fill(Color.mainPink)
                                             )
                                     }
                                     
@@ -401,21 +403,6 @@ struct AddTravelView: View {
         }
     }
     
-//    var nextButton: some View {
-//        NavigationLink(destination: AddMemberView(addViewModel: viewModel, participantArr: [""], startDate: $viewModel.startDate, endDate: $viewModel.endDate)) {
-//            ZStack {
-//                Rectangle()
-//                    .frame(width: 134, height: 45)
-//                    .foregroundStyle(viewModel.isSelectedStartDate ? Color.black : Color.gray200)
-//                    .cornerRadius(16)
-//                
-//                Text("다음")
-//                    .font(.subhead3_2)
-//                    .foregroundStyle(Color.white)
-//            }
-//        }
-//    }
-//    
     var backButton: some View {
         Button {
             dismiss()

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -25,7 +25,7 @@ struct PreviousTravelView: View {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0 ..< travelCnt, id: \.self) { index in
                             VStack {
-                                ZStack {
+                                ZStack(alignment: .top) {
                                     Image("basicImage")
                                         .resizable()
                                         .scaledToFill()
@@ -42,20 +42,22 @@ struct PreviousTravelView: View {
                                             )
                                         )
                                         .cornerRadius(10)
+                                        
+                                    VStack {
+                                        Spacer()
+                                        
+                                        HStack {
+                                            Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
                                     
-                                    Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                            Text("~")
+                                        }
                                         .font(.caption2)
                                         .foregroundStyle(Color.white.opacity(0.75))
-                                    +
-                                    Text("~ \n")
-                                        .font(.caption2)
-                                        .foregroundStyle(Color.white.opacity(0.75))
-                                    
-                                    +
-                                    Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
-                                        .font(.caption2)
-                                        .foregroundStyle(Color.white.opacity(0.75))
-                                    
+                                        
+                                        Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                            .font(.caption2)
+                                            .foregroundStyle(Color.white.opacity(0.75))
+                                    }
                                 }
                                 
                                 Text(previousTravel?[index].name ?? "제목 미정")
@@ -133,7 +135,8 @@ struct PreviousTravelView: View {
                                 .frame(width: 5, height: 5)
                         }
                     }
-                    .offset(y: 85)
+                    // TempView 가 있을 땐 125 없을 땐 85
+                    .offset(y: 125)
                 }
             }
         }

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -12,6 +12,7 @@ struct PreviousTravelView: View {
     @ObservedObject var viewModel = PreviousTravelViewModel()
     @State var previousTravel: [Travel]?
     @State private var travelCnt: Int = 0
+    @State private var currentPage = 0
     
     var body: some View {
         
@@ -69,69 +70,93 @@ struct PreviousTravelView: View {
                     Spacer()
                 }
             } else {
-                TabView {
-                    ForEach(0 ..< (travelCnt+5)/6, id: \.self) { page in
-                        VStack {
-                            LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
-                                    VStack {
-                                        ZStack {
-                                            Image("basicImage")
-                                                .resizable()
-                                                .scaledToFill()
-                                                .frame(width: 110, height: 80)
-                                                .cornerRadius(10)
-                                                .background(
-                                                    LinearGradient(
-                                                        stops: [
-                                                            Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                            Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
-                                                        ],
-                                                        startPoint: UnitPoint(x: 0.5, y: 0),
-                                                        endPoint: UnitPoint(x: 0.5, y: 1)
-                                                    )
-                                                )
-                                                .cornerRadius(10)
-                                            
-                                            Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                            +
-                                            Text("~ \n")
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                            
-                                            +
-                                            Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                            
+                ZStack {
+                    ScrollView(.init()) {
+                        TabView(selection: $currentPage) {
+                            ForEach(0 ..< (travelCnt+5)/6, id: \.self) { page in
+                                VStack {
+                                    LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
+                                        ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
+                                            VStack {
+                                                ZStack {
+                                                    Image("basicImage")
+                                                        .resizable()
+                                                        .scaledToFill()
+                                                        .frame(width: 110, height: 80)
+                                                        .cornerRadius(10)
+                                                        .background(
+                                                            LinearGradient(
+                                                                stops: [
+                                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                                    Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
+                                                                ],
+                                                                startPoint: UnitPoint(x: 0.5, y: 0),
+                                                                endPoint: UnitPoint(x: 0.5, y: 1)
+                                                            )
+                                                        )
+                                                        .cornerRadius(10)
+                                                    
+                                                    Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    +
+                                                    Text("~ \n")
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    
+                                                    +
+                                                    Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    
+                                                }
+                                                
+                                                Text(previousTravel?[index].name ?? "제목 미정")
+                                                    .font(.subhead1)
+                                                    .lineLimit(1)
+                                            }
                                         }
-                                        
-                                        Text(previousTravel?[index].name ?? "제목 미정")
-                                            .font(.subhead1)
-                                            .lineLimit(1)
                                     }
+                                    Spacer()
                                 }
                             }
-                            Spacer()
+                        }
+                        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 32)
+                    }
+                    
+                    HStack(spacing: 6) {
+                        ForEach(0..<(travelCnt+5)/6, id: \.self) { index in
+                            Capsule()
+                                .fill(currentPage == index ? Color.black : Color.gray200)
+                                .frame(width: 5, height: 5)
                         }
                     }
+                    .offset(y: 85)
                 }
-                .tabViewStyle(PageTabViewStyle())
-                .indexViewStyle(.page(backgroundDisplayMode: .always))
-                .padding(.horizontal, 20)
-                .padding(.vertical, 32)
             }
         }
         .padding(.top, 12)
         .onAppear {
+            let screenWidth = getWidth()
+            self.currentPage = Int(round(offset / screenWidth))
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 viewModel.fetchTravel()
                 self.previousTravel = viewModel.filterPreviouTravel(todayDate: Date())
                 self.travelCnt = Int(previousTravel?.count ?? 0)
             }
         }
+    }
+    
+    private func getWidth() -> CGFloat {
+        return UIScreen.main.bounds.width
+    }
+    
+    private var offset: CGFloat {
+        let screenWidth = getWidth()
+        return CGFloat(currentPage) * screenWidth
     }
 }
 

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -184,7 +184,6 @@ struct TravelListView: View {
 struct TravelTabView: View {
     
     @State var currentTab: Int = 0
-//    @State var disableGesture = false
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -203,6 +202,10 @@ struct TravelTabView: View {
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             
+            Divider()
+                .frame(height: 1)
+                .padding(.top, 24)
+            
             TabBarView(currentTab: self.$currentTab)
         }
     }
@@ -214,7 +217,7 @@ struct TabBarView: View {
     
     var tabBarOptions: [String] = ["지난 여행", "다가오는 여행"]
     var body: some View {
-        HStack(spacing: 20) {
+        HStack {
             ForEach(Array(zip(self.tabBarOptions.indices,
                               self.tabBarOptions)),
                     id: \.0,
@@ -225,7 +228,6 @@ struct TabBarView: View {
                            tab: index)
             })
         }
-        .padding(.horizontal)
         .background(Color.clear)
         .frame(height: 10)
         .ignoresSafeArea(.all)

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -13,10 +13,12 @@ struct TravelListView: View {
     @ObservedObject var viewModel = TravelListViewModel()
     @State var nowTravel: [Travel]?
     @State private var travelCount: Int = 0
-
+//    @State var offset: CGFloat = 0
+    @State private var currentPage = 0
+    
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: 0) {
                 titleHeader
                 
                 nowTravelingView
@@ -91,93 +93,141 @@ struct TravelListView: View {
                     )
                     .cornerRadius(10)
             } else {
-                TabView {
-                    ForEach(0..<travelCount, id: \.self) { index in
-                        ZStack(alignment: .top) {
-                            Rectangle()
-                                .foregroundColor(.clear)
-                                .frame(width: 350, height: 137 + 46)
-                            
-                            Rectangle()
-                                .foregroundColor(.clear)
-                                .frame(width: 350, height: 137)
-                                .background(
-                                    Image("testImage")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fill)
+                ZStack {
+                    ScrollView(.init()) {
+                        TabView(selection: $currentPage) {
+                            ForEach(0..<travelCount, id: \.self) { index in
+                                ZStack(alignment: .top) {
+                                    Rectangle()
+                                        .foregroundColor(.clear)
+                                        .frame(width: 350, height: 137 + 46)
                                     
-                                )
-                                .cornerRadius(10)
-                            
-                            Rectangle()
-                              .foregroundColor(.clear)
-                              .frame(width: 350, height: 137)
-                              .background(
-                                LinearGradient(
-                                  stops: [
-                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                    Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
-                                  ],
-                                  startPoint: UnitPoint(x: 0.5, y: 0),
-                                  endPoint: UnitPoint(x: 0.5, y: 1)
-                                )
-                              )
-                              .cornerRadius(10)
-                            
-                            VStack(alignment: .leading) {
-                                Spacer()
-                                
-                                Text("Day 3❌")
-                                    .font(.caption1)
-                                    .foregroundStyle(Color.white)
-                                    .opacity(0.75)
-                                    .padding(.leading, 16)
-                                
-                                Text(nowTravel?[index].name ?? "제목 미정")
-                                    .font(.display1)
-                                    .foregroundStyle(Color.white)
-                                    .padding(.leading, 16)
-                                
-                                HStack {
-                                    Group {
-                                        Text(nowTravel?[index].startDate ?? Date(), formatter: TravelListViewModel.dateFormatter) +
-                                        Text(" ~ ") +
-                                        Text(nowTravel?[index].endDate ?? Date(), formatter: TravelListViewModel.dateFormatter)
-                                    }
-                                    .font(.subhead2_2)
-                                    .foregroundStyle(Color.white.opacity(0.75))
-                                    .padding(.leading, 16)
+                                    Rectangle()
+                                        .foregroundColor(.clear)
+                                        .frame(width: 350, height: 137)
+                                        .background(
+                                            Image("testImage")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                            
+                                        )
+                                        .cornerRadius(10)
                                     
-                                    Spacer()
+                                    Rectangle()
+                                        .foregroundColor(.clear)
+                                        .frame(width: 350, height: 137)
+                                        .background(
+                                            LinearGradient(
+                                                stops: [
+                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                    Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
+                                                ],
+                                                startPoint: UnitPoint(x: 0.5, y: 0),
+                                                endPoint: UnitPoint(x: 0.5, y: 1)
+                                            )
+                                        )
+                                        .cornerRadius(10)
                                     
-                                    HStack {
-                                        Image(systemName: "person.fill")
-                                            .foregroundStyle(Color.white)
+                                    VStack(alignment: .leading) {
+                                        Spacer()
                                         
-                                        Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? ["me"]))
-                                            .font(.caption2)
+                                        Text("Day 3❌")
+                                            .font(.caption1)
                                             .foregroundStyle(Color.white)
+                                            .opacity(0.75)
+                                            .padding(.leading, 16)
+                                        
+                                        Text(nowTravel?[index].name ?? "제목 미정")
+                                            .font(.display1)
+                                            .foregroundStyle(Color.white)
+                                            .padding(.leading, 16)
+                                        
+                                        HStack {
+                                            Group {
+                                                Text(nowTravel?[index].startDate ?? Date(), formatter: TravelListViewModel.dateFormatter) +
+                                                Text(" ~ ") +
+                                                Text(nowTravel?[index].endDate ?? Date(), formatter: TravelListViewModel.dateFormatter)
+                                            }
+                                            .font(.subhead2_2)
+                                            .foregroundStyle(Color.white.opacity(0.75))
+                                            .padding(.leading, 16)
+                                            
+                                            Spacer()
+                                            
+                                            HStack {
+                                                Image(systemName: "person.fill")
+                                                    .foregroundStyle(Color.white)
+                                                
+                                                Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? ["me"]))
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color.white)
+                                                
+                                            }
+                                            .padding(.trailing, 16)
+                                        }
                                         
                                     }
-                                    .padding(.trailing, 16)
+                                    .padding(.bottom, 16)
+                                    .frame(width: 350, height: 137)
+                                    
                                 }
-                                
                             }
-                            .padding(.bottom, 16)
-                            .frame(width: 350, height: 137)
-                            
+                        }
+                        .frame(width: 350, height: 230)
+                        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                        //                    .overlay(
+                        //                        HStack(spacing: 15) {
+                        //                            ForEach(0..<travelCount, id: \.self) { index in
+                        //                                Capsule()
+                        //                                    .fill(Color.black)
+                        //                                    .frame(width: 7, height: 7)
+                        //                                    .opacity(currentPage == index ? 1 : 0.5)
+                        //                            }
+                        //                        }
+                        //                            .frame(width: 0, height: 0), alignment: .bottom
+                        //
+                        //                    )
+                        //                    .onAppear {
+                        //                        let screenWidth = getWidth()
+                        //                        self.currentPage = Int(round(offset / screenWidth))
+                        //                    }
+                    }
+                    //                    .background(Color.black)
+                    HStack(spacing: 6) {
+                        ForEach(0..<travelCount, id: \.self) { index in
+                            Capsule()
+                                .fill(currentPage == index ? Color.black : Color.gray200)
+                                .frame(width: 5, height: 5)
                         }
                     }
+                    .offset(y: 60)
+                    .onAppear {
+                        let screenWidth = getWidth()
+                        self.currentPage = Int(round(offset / screenWidth))
+                    }
                 }
-                .frame(width: 350, height: 230)
-                .tabViewStyle(PageTabViewStyle())
-                .indexViewStyle(.page(backgroundDisplayMode: .always))
+                .frame(height: 200)
             }
         }
     }
     
+    func getWidth() -> CGFloat {
+        return UIScreen.main.bounds.width
+    }
+    
+    var offset: CGFloat {
+        let screenWidth = getWidth()
+        return CGFloat(currentPage) * screenWidth
+    }
+    
     private var tempTravelView: some View {
         EmptyView()
+    }
+}
+
+extension View {
+    func getWidth() -> CGFloat {
+        return UIScreen.main.bounds.width
     }
 }
 

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -24,6 +24,8 @@ struct TravelListView: View {
                 
                 TempTravelView()
                 
+                Spacer(minLength: 16)
+                
                 TravelTabView()
                 
             }
@@ -217,9 +219,37 @@ extension View {
 }
 
 struct TempTravelView: View {
+    @State var isTempTravelExist = true
+    
     var body: some View {
-        Rectangle()
-            .frame(width: 250, height: 0)
+        if !isTempTravelExist {
+            Rectangle()
+                .frame(width: 250, height: 0)
+        } else {
+            HStack(alignment: .center, spacing: 45) {
+                Image("franceFlag")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 36, height: 36)
+                    .background(.white)
+                    .shadow(color: .black.opacity(0.25), radius: 1, x: 0, y: 0)
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("분류가 필요한 지출 내역 1개")
+                        .font(.subhead2_1)
+                        .foregroundColor(Color.black)
+                    
+                    Text("최근 지출 11,650원")
+                        .font(.caption2)
+                        .foregroundColor(Color.gray300)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 15)
+            .frame(width: 350, alignment: .leading)
+            .background(Color(red: 0.96, green: 0.96, blue: 0.96))
+            .cornerRadius(10)
+        }
     }
 }
 

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -128,11 +128,15 @@ struct TravelListView: View {
                                     VStack(alignment: .leading) {
                                         Spacer()
                                         
-                                        Text("Day 3❌")
-                                            .font(.caption1)
-                                            .foregroundStyle(Color.white)
-                                            .opacity(0.75)
-                                            .padding(.leading, 16)
+                                        Group {
+                                            Text("Day ")
+                                            +
+                                            Text("\(viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()))")
+                                        }
+                                        .font(.caption1)
+                                        .foregroundStyle(Color.white)
+                                        .opacity(0.75)
+                                        .padding(.leading, 16)
                                         
                                         Text(nowTravel?[index].name ?? "제목 미정")
                                             .font(.display1)

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -13,7 +13,6 @@ struct TravelListView: View {
     @ObservedObject var viewModel = TravelListViewModel()
     @State var nowTravel: [Travel]?
     @State private var travelCount: Int = 0
-//    @State var offset: CGFloat = 0
     @State private var currentPage = 0
     
     var body: some View {
@@ -23,9 +22,7 @@ struct TravelListView: View {
                 
                 nowTravelingView
                 
-                tempTravelView
-                
-                Spacer()
+                TempTravelView()
                 
                 TravelTabView()
                 
@@ -175,24 +172,7 @@ struct TravelListView: View {
                         }
                         .frame(width: 350, height: 230)
                         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                        //                    .overlay(
-                        //                        HStack(spacing: 15) {
-                        //                            ForEach(0..<travelCount, id: \.self) { index in
-                        //                                Capsule()
-                        //                                    .fill(Color.black)
-                        //                                    .frame(width: 7, height: 7)
-                        //                                    .opacity(currentPage == index ? 1 : 0.5)
-                        //                            }
-                        //                        }
-                        //                            .frame(width: 0, height: 0), alignment: .bottom
-                        //
-                        //                    )
-                        //                    .onAppear {
-                        //                        let screenWidth = getWidth()
-                        //                        self.currentPage = Int(round(offset / screenWidth))
-                        //                    }
                     }
-                    //                    .background(Color.black)
                     HStack(spacing: 6) {
                         ForEach(0..<travelCount, id: \.self) { index in
                             Capsule()
@@ -211,23 +191,31 @@ struct TravelListView: View {
         }
     }
     
-    func getWidth() -> CGFloat {
+    private func getWidth() -> CGFloat {
         return UIScreen.main.bounds.width
     }
     
-    var offset: CGFloat {
+    private var offset: CGFloat {
         let screenWidth = getWidth()
         return CGFloat(currentPage) * screenWidth
     }
     
-    private var tempTravelView: some View {
-        EmptyView()
-    }
+//    private var tempTravelView: some View {
+//        Rectangle()
+//            .frame(width: 250, height: 68)
+//    }
 }
 
 extension View {
     func getWidth() -> CGFloat {
         return UIScreen.main.bounds.width
+    }
+}
+
+struct TempTravelView: View {
+    var body: some View {
+        Rectangle()
+            .frame(width: 250, height: 0)
     }
 }
 
@@ -250,11 +238,12 @@ struct TravelTabView: View {
                     })
                     .tag(1)
             }
+            .padding(.top, 12)
             .tabViewStyle(.page(indexDisplayMode: .never))
             
             Divider()
                 .frame(height: 1)
-                .padding(.top, 24)
+                .padding(.top, 44)
             
             TabBarView(currentTab: self.$currentTab)
         }
@@ -279,7 +268,8 @@ struct TabBarView: View {
             })
         }
         .background(Color.clear)
-        .frame(height: 10)
+        .frame(height: 30)
+        .padding(.top, 8)
         .ignoresSafeArea(.all)
     }
 }

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -132,7 +132,8 @@ struct UpcomingTravelView: View {
                                 .frame(width: 5, height: 5)
                         }
                     }
-                    .offset(y: 85)
+                    // TempView 가 있을 땐 125 없을 땐 85
+                    .offset(y: 125)
                 }
             }
         }

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -12,6 +12,7 @@ struct UpcomingTravelView: View {
     @ObservedObject var viewModel = UpcomingTravelViewModel()
     @State var upcomingTravel: [Travel]?
     @State private var travelCnt: Int = 0
+    @State private var currentPage = 0
     
     var body: some View {
         ZStack {
@@ -67,69 +68,94 @@ struct UpcomingTravelView: View {
                     Spacer()
                 }
             } else {
-                TabView {
-                    ForEach(0 ..< (travelCnt+5)/6, id: \.self) { page in
-                        VStack {
-                            LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
-                                    VStack {
-                                        ZStack {
-                                            Image("basicImage")
-                                                .resizable()
-                                                .scaledToFill()
-                                                .frame(width: 110, height: 80)
-                                                .cornerRadius(10)
-                                                .background(
-                                                    LinearGradient(
-                                                        stops: [
-                                                            Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                            Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
-                                                        ],
-                                                        startPoint: UnitPoint(x: 0.5, y: 0),
-                                                        endPoint: UnitPoint(x: 0.5, y: 1)
-                                                    )
-                                                )
-                                                .cornerRadius(10)
-                                            
-                                            Text(upcomingTravel?[index].startDate ?? Date(), formatter: UpcomingTravelViewModel.dateFormatter)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                            +
-                                            Text("~ \n")
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                            
-                                            +
-                                            Text(upcomingTravel?[index].endDate ?? Date(), formatter: UpcomingTravelViewModel.dateFormatter)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
+                ZStack {
+                    ScrollView(.init()) {
+                        TabView(selection: $currentPage) {
+                            ForEach(0 ..< (travelCnt+5)/6, id: \.self) { page in
+                                VStack {
+                                    LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
+                                        ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
+                                            VStack {
+                                                ZStack {
+                                                    Image("basicImage")
+                                                        .resizable()
+                                                        .scaledToFill()
+                                                        .frame(width: 110, height: 80)
+                                                        .cornerRadius(10)
+                                                        .background(
+                                                            LinearGradient(
+                                                                stops: [
+                                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                                    Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
+                                                                ],
+                                                                startPoint: UnitPoint(x: 0.5, y: 0),
+                                                                endPoint: UnitPoint(x: 0.5, y: 1)
+                                                            )
+                                                        )
+                                                        .cornerRadius(10)
+                                                    
+                                                    Text(upcomingTravel?[index].startDate ?? Date(), formatter: UpcomingTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    +
+                                                    Text("~ \n")
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    
+                                                    +
+                                                    Text(upcomingTravel?[index].endDate ?? Date(), formatter: UpcomingTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                }
+                                                
+                                                Text(upcomingTravel?[index].name ?? "제목 미정")
+                                                    .font(.subhead1)
+                                                    .lineLimit(1)
+                                            }
                                         }
-                                        
-                                        Text(upcomingTravel?[index].name ?? "제목 미정")
-                                            .font(.subhead1)
-                                            .lineLimit(1)
                                     }
+                                    
+                                    Spacer()
                                 }
                             }
-                            
-                            Spacer()
+                        }
+                        .tabViewStyle(PageTabViewStyle())
+                        .indexViewStyle(.page(backgroundDisplayMode: .always))
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 32)
+                    }
+                    
+                    HStack(spacing: 6) {
+                        ForEach(0..<(travelCnt+5)/6, id: \.self) { index in
+                            Capsule()
+                                .fill(currentPage == index ? Color.black : Color.gray200)
+                                .frame(width: 5, height: 5)
                         }
                     }
+                    .offset(y: 85)
                 }
-                .tabViewStyle(PageTabViewStyle())
-                .indexViewStyle(.page(backgroundDisplayMode: .always))
-                .padding(.horizontal, 20)
-                .padding(.vertical, 32)
             }
         }
         .padding(.top, 12)
         .onAppear {
+            let screenWidth = getWidth()
+            self.currentPage = Int(round(offset / screenWidth))
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 viewModel.fetchTravel()
                 self.upcomingTravel = viewModel.filterUpcomingTravel(todayDate: Date())
                 self.travelCnt = Int(upcomingTravel?.count ?? 0)
             }
         }
+    }
+    
+    private func getWidth() -> CGFloat {
+        return UIScreen.main.bounds.width
+    }
+    
+    private var offset: CGFloat {
+        let screenWidth = getWidth()
+        return CGFloat(currentPage) * screenWidth
     }
 }
 

--- a/UMM/ViewModel/TravelListViewModel.swift
+++ b/UMM/ViewModel/TravelListViewModel.swift
@@ -56,4 +56,12 @@ class TravelListViewModel: ObservableObject {
         
         return formatter
     }()
+    
+    // 선택된 Travel의 startDate와 오늘 날짜의 차이를 구하는 함수
+    // 날짜 두개 input -> 차이값 아웃풋
+    func differenceBetweenToday(today: Date, startDate: Date) -> Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.day], from: startDate, to: today)
+        return components.day ?? 0
+    }
 }


### PR DESCRIPTION
## 👀 이슈
- #91 
- #118 
- #119 

## 💡 작업 내용
- 디데이 계산 함수를 추가
- 각각의 page indicator 수정
- 탭 바 아이템에 가로선 추가
- 임시 기록뷰의 UI 구현
- AddMemberView에서 뒤로 가기 버튼을 눌렀을 때도 여행이 생성되는 오류 수정

## 📱스크린샷
<img width="40%" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/f921b91b-b2f4-418d-8723-ae094709d252">

## 🚨 참고 사항
- 아직 tabView들 사이의 padding을 주는 방법을 찾지 못했어요..🥹
- 시간 기준이 한국이 아니라서 디데이 계산에 차이가 생깁니다.
- tabView에 기본으로 생기는 padding이 존재해서 page indicator의 위치를 VStack으로 해결할 수 없어서 offset으로 지정했습니다...


## (Optional) 🤔 고민한 점

- page indicator

```swift
HStack(spacing: 6) {
                        ForEach(0..<travelCount, id: \.self) { index in
                            Capsule()
                                .fill(currentPage == index ? Color.black : Color.gray200)
                                .frame(width: 5, height: 5)
                        }
                    }
                    .offset(y: 60)
                    .onAppear {
                        let screenWidth = getWidth()
                        self.currentPage = Int(round(offset / screenWidth))
                    }

    var offset: CGFloat {
        let screenWidth = getWidth()
        return CGFloat(currentPage) * screenWidth
    }
    
    func getWidth() -> CGFloat {
        return UIScreen.main.bounds.width
    }
```
> 화면 크기를 이용해 현재 페이지 여부를 판단합니다.
