### PR TITLE
⚡️[#122] TravelDetailView에 데이터를 추가합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		57CE9C732ADE4CAE00EDAD11 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CE9C722ADE4CAE00EDAD11 /* Currency.swift */; };
 		57CE9C752ADE97A600EDAD11 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CE9C742ADE97A600EDAD11 /* Date+Extension.swift */; };
 		57EA42202ADE38EE006CA587 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EA421F2ADE38EE006CA587 /* Country.swift */; };
+		C157600C2AEACADC0089FFE5 /* TravelDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C157600B2AEACADC0089FFE5 /* TravelDetailViewModel.swift */; };
 		C17550522AD54FB000A61BE5 /* TravelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550512AD54FB000A61BE5 /* TravelListView.swift */; };
 		C17550542AD54FC900A61BE5 /* AddTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550532AD54FC900A61BE5 /* AddTravelView.swift */; };
 		C17550592AD57B6500A61BE5 /* AddTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17550582AD57B6500A61BE5 /* AddTravelViewModel.swift */; };
@@ -116,6 +117,7 @@
 		57CE9C722ADE4CAE00EDAD11 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		57CE9C742ADE97A600EDAD11 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		57EA421F2ADE38EE006CA587 /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
+		C157600B2AEACADC0089FFE5 /* TravelDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDetailViewModel.swift; sourceTree = "<group>"; };
 		C17550512AD54FB000A61BE5 /* TravelListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListView.swift; sourceTree = "<group>"; };
 		C17550532AD54FC900A61BE5 /* AddTravelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTravelView.swift; sourceTree = "<group>"; };
 		C17550582AD57B6500A61BE5 /* AddTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTravelViewModel.swift; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 				C19AFAF52AE163990037A5F5 /* PreviousTravelViewModel.swift */,
 				C19AFAF72AE16C600037A5F5 /* UpcomingTravelViewModel.swift */,
 				572BE1E72AE49FB5005933E7 /* Redrawer.swift */,
+				C157600B2AEACADC0089FFE5 /* TravelDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -543,6 +546,7 @@
 				C179660E2ADD6BF90036E866 /* Color+Extension.swift in Sources */,
 				C19AFAEC2AE107460037A5F5 /* SettingView.swift in Sources */,
 				57C41DFC2AD4F1EB00345253 /* Persistence.swift in Sources */,
+				C157600C2AEACADC0089FFE5 /* TravelDetailViewModel.swift in Sources */,
 				C17550542AD54FC900A61BE5 /* AddTravelView.swift in Sources */,
 				C19AFAF02AE116FF0037A5F5 /* PreviousTravelView.swift in Sources */,
 				572BE1E82AE49FB5005933E7 /* Redrawer.swift in Sources */,

--- a/UMM/View/Travel/CompleteAddTravelView.swift
+++ b/UMM/View/Travel/CompleteAddTravelView.swift
@@ -15,20 +15,7 @@ struct CompleteAddTravelView: View {
     @Binding var travelID: UUID
     @State var travelNM: String
     @State var selectedTravel: [Travel]?
-    
-    @Binding var isDisappear: Bool 
-//    {
-//        didSet {
-//            if isDisappear {
-//                print("traveelID", travelID)
-//                viewModel.fetchTravel()
-//                self.selectedTravel = viewModel.filterTravelByID(selectedTravelID: travelID)
-//                print("selectedTravel", selectedTravel!)
-//            }
-//        }
-//    }
-    
-//    let filteredTravel = CompleteAddTravelViewModel.filterTravelByID(selectedTravelID: selectedTravel?.id ?? UUID())
+    @Binding var isDisappear: Bool
     
     var body: some View {
         VStack {

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -25,7 +25,12 @@ struct PreviousTravelView: View {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0 ..< travelCnt, id: \.self) { index in
                             VStack {
-                                NavigationLink(destination: TravelDetailView(), label: {
+                                NavigationLink(destination: TravelDetailView(travelName: previousTravel?[index].name ?? "",
+                                                                             startDate: previousTravel?[index].startDate ?? Date(),
+                                                                             endDate: previousTravel?[index].endDate ?? Date(),
+                                                                             dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: previousTravel?[index].startDate ?? Date()),
+                                                                             participantCnt: previousTravel?[index].participantArray?.count ?? 0,
+                                                                             participantArr: previousTravel?[index].participantArray ?? []), label: {
                                     ZStack {
                                         Image("basicImage")
                                             .resizable()
@@ -81,7 +86,12 @@ struct PreviousTravelView: View {
                             LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                                 ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
                                     VStack {
-                                        NavigationLink(destination: TravelDetailView(), label: {
+                                        NavigationLink(destination: TravelDetailView(travelName: previousTravel?[index].name ?? "",
+                                                                                     startDate: previousTravel?[index].startDate ?? Date(),
+                                                                                     endDate: previousTravel?[index].endDate ?? Date(),
+                                                                                     dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: previousTravel?[index].startDate ?? Date()),
+                                                                                     participantCnt: previousTravel?[index].participantArray?.count ?? 0,
+                                                                                     participantArr: previousTravel?[index].participantArray ?? []), label: {
                                             ZStack {
                                                 Image("basicImage")
                                                     .resizable()

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -136,10 +136,10 @@ struct TravelDetailView: View {
         VStack {
             Rectangle()
                 .foregroundColor(.clear)
-                .frame(width: 326, height: 0.5)
+                .frame(width: UIScreen.main.bounds.width - 40, height: 0.5)
                 .background(.white)
             
-            HStack {
+            HStack(alignment: .center) {
                 VStack(alignment: .leading) {
                     Text("시작일")
                         .font(.subhead1)
@@ -172,11 +172,11 @@ struct TravelDetailView: View {
                 Spacer()
             }
             .padding(.vertical, 22)
-            .frame(width: 326)
+            .frame(width: UIScreen.main.bounds.width - 40)
             
             Rectangle()
                 .foregroundColor(.clear)
-                .frame(width: 326, height: 0.5)
+                .frame(width: UIScreen.main.bounds.width - 40, height: 0.5)
                 .background(.white)
         }
         .padding(.horizontal, 20)

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -33,13 +33,10 @@ struct TravelDetailView: View {
                     )
                     .ignoresSafeArea()
                 
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 20) {
                     Spacer()
                     // 1. 여행중 + Day 3
                     dayCounter
-                    
-                    // 2. 여행 제목 (ex) 니코랑 여행)
-                    travelTitle
                     
                     // 3. 여행 국가
                     travelCountry
@@ -49,59 +46,77 @@ struct TravelDetailView: View {
                     
                     // 5. 힘께하는 사람
                     participantGroup
+                    
                     Spacer()
                     
                     // 6. 버튼
+                    HStack {
+                        MediumButtonUnactive(title: "가계부 보기", action: {
+                            // 선택값 초기화
+                            NavigationUtil.popToRootView()
+                        })
+                        
+                        MediumButtonActive(title: "지출 기록하기", action: {
+                            NavigationUtil.popToRootView()
+                        })
+                    }
                 }
             }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack {
-                        NavigationLink(destination: AddTravelView(), label: {
+                        Button {
+                            
+                        } label: {
                             Image("pencil")
                                 .frame(width: 20, height: 20)
-                        })
+                        }
                         
-                        NavigationLink(destination: SettingView(), label: {
+                        Button {
+                            NavigationUtil.popToRootView()
+                        } label: {
                             Image("xmark_white")
                                 .frame(width: 20, height: 20)
-                        })
+                        }
                     }
                 }
             }
         }
         .toolbar(.hidden, for: .tabBar)
+        .navigationBarBackButtonHidden()
     }
     
     private var dayCounter: some View {
-        HStack {
-            HStack(alignment: .center, spacing: 10) {
-                Text("여행 중")
-                    .font(
-                        Font.custom("Pretendard", size: 14)
-                            .weight(.medium)
-                    )
-                    .foregroundColor(Color.mainPink)
-            }
-            .padding(.horizontal, 11)
-            .padding(.vertical, 7)
-            .background(.white)
-            .cornerRadius(5)
-            
-            Group {
-                Text("DAY")
-                +
-                Text("\(dayCnt)")
-            }
+        VStack(alignment: .leading) {
+            HStack {
+                HStack(alignment: .center, spacing: 10) {
+                    Text("여행 중")
+                        .font(
+                            Font.custom("Pretendard", size: 14)
+                                .weight(.medium)
+                        )
+                        .foregroundColor(Color.mainPink)
+                }
+                .padding(.horizontal, 11)
+                .padding(.vertical, 7)
+                .background(.white)
+                .cornerRadius(5)
+                
+                Group {
+                    Text("DAY ")
+                    +
+                    Text("\(dayCnt)")
+                }
                 .font(.subhead2_1)
                 .foregroundStyle(Color.white)
+            }
+            
+            Text("\(travelName)")
+                .font(.display3)
+                .foregroundStyle(Color.white)
+                
         }
-    }
-    
-    private var travelTitle: some View {
-        Text("\(travelName)")
-            .font(.display3)
-            .foregroundStyle(Color.white)
+        .padding(.horizontal, 20)
     }
     
     private var travelCountry: some View {
@@ -114,6 +129,7 @@ struct TravelDetailView: View {
                 Text("❌ 여행 국가 개수대로 국기랑 국가명 쌓기 ❌")
             }
         }
+        .padding(.horizontal, 20)
     }
     
     private var dateBox: some View {
@@ -124,26 +140,30 @@ struct TravelDetailView: View {
                 .background(.white)
             
             HStack {
-                Spacer()
-                
                 VStack(alignment: .leading) {
                     Text("시작일")
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
+                        .padding(.bottom, 8)
                     Text(startDate, formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
                 }
+                
+                Spacer()
                 
                 Rectangle()
                 .foregroundColor(.clear)
                 .frame(width: 1, height: 49)
                 .background(.white)
                 
+                Spacer()
+                
                 VStack(alignment: .leading) {
                     Text("종료일")
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
+                        .padding(.bottom, 8)
                     Text(endDate, formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
@@ -151,34 +171,38 @@ struct TravelDetailView: View {
                 
                 Spacer()
             }
+            .padding(.vertical, 22)
+            .frame(width: 326)
             
             Rectangle()
                 .foregroundColor(.clear)
                 .frame(width: 326, height: 0.5)
                 .background(.white)
         }
+        .padding(.horizontal, 20)
     }
     
     private var participantGroup: some View {
-        VStack {
+        VStack(alignment: .leading) {
             Text("함께하는 사람")
                 .font(.subhead1)
+                .foregroundStyle(Color.white)
             
             HStack {
                 HStack(alignment: .center, spacing: 8) {
                     Text("me")
-                      .font(
-                        Font.custom("Pretendard", size: 16)
-                          .weight(.medium)
-                      )
-                      .foregroundColor(Color.gray200)
+                        .font(
+                            Font.custom("Pretendard", size: 16)
+                                .weight(.medium)
+                        )
+                        .foregroundColor(Color.gray200)
                     
                     Text("나")
-                      .font(
-                        Font.custom("Pretendard", size: 16)
-                          .weight(.medium)
-                      )
-                      .foregroundColor(.white)
+                        .font(
+                            Font.custom("Pretendard", size: 16)
+                                .weight(.medium)
+                        )
+                        .foregroundColor(.white)
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
@@ -201,6 +225,7 @@ struct TravelDetailView: View {
                 }
             }
         }
+        .padding(.horizontal, 20)
     }
 }
 

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -8,6 +8,14 @@
 import SwiftUI
 
 struct TravelDetailView: View {
+    
+    @State var travelName: String
+    @State var startDate: Date
+    @State var endDate: Date
+    @State var dayCnt: Int
+    @State var participantCnt: Int
+    @State var participantArr: [String]
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -80,14 +88,18 @@ struct TravelDetailView: View {
             .background(.white)
             .cornerRadius(5)
             
-            Text("❌DAY 3❌")
+            Group {
+                Text("DAY")
+                +
+                Text("\(dayCnt)")
+            }
                 .font(.subhead2_1)
                 .foregroundStyle(Color.white)
         }
     }
     
     private var travelTitle: some View {
-        Text("여행 제목")
+        Text("\(travelName)")
             .font(.display3)
             .foregroundStyle(Color.white)
     }
@@ -114,11 +126,11 @@ struct TravelDetailView: View {
             HStack {
                 Spacer()
                 
-                VStack {
+                VStack(alignment: .leading) {
                     Text("시작일")
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
-                    Text("시작 date")
+                    Text(startDate, formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
                 }
@@ -128,11 +140,11 @@ struct TravelDetailView: View {
                 .frame(width: 1, height: 49)
                 .background(.white)
                 
-                VStack {
+                VStack(alignment: .leading) {
                     Text("종료일")
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
-                    Text("종료 date")
+                    Text(endDate, formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
                 }
@@ -173,12 +185,25 @@ struct TravelDetailView: View {
                 .background(.white.opacity(0.25))
                 .cornerRadius(18.07692)
                 
-                Text("me 나 는 디폴트, 옆으로 참여자 추가되도록 ")
+                ForEach(0..<participantCnt, id: \.self) { index in
+                    HStack(alignment: .center, spacing: 10) {
+                        Text("\(participantArr[index])")
+                            .font(
+                                Font.custom("Pretendard", size: 16)
+                                    .weight(.medium)
+                            )
+                            .foregroundColor(.white)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.white.opacity(0.25))
+                    .cornerRadius(18.07692)
+                }
             }
         }
     }
 }
 
-#Preview {
-    TravelDetailView()
-}
+// #Preview {
+//     TravelDetailView()
+// }

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -219,8 +219,8 @@ struct TravelListView: View {
         // Travel의 "Default" 라는 이름의 여행이 길이가 1이상이면 임시 기록이 존재함
         // 뷰모델에서 Default이름 가진 여행 fetch 필요
         ZStack {
-            if defaultTravel?.count != 0 {
-                
+            if defaultTravel?.count == 0 {
+
                 EmptyView()
                 
             } else {

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -98,7 +98,12 @@ struct TravelListView: View {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
                             ForEach(0..<travelCount, id: \.self) { index in
-                                NavigationLink(destination: TravelDetailView(), label: {
+                                NavigationLink(destination: TravelDetailView(travelName: nowTravel?[index].name ?? "",
+                                                                             startDate: nowTravel?[index].startDate ?? Date(),
+                                                                             endDate: nowTravel?[index].endDate ?? Date(),
+                                                                             dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()),
+                                                                             participantCnt: nowTravel?[index].participantArray?.count ?? 0,
+                                                                             participantArr: nowTravel?[index].participantArray ?? []), label: {
                                     ZStack(alignment: .top) {
                                         Rectangle()
                                             .foregroundColor(.clear)

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -23,7 +23,7 @@ struct TravelListView: View {
                 
                 nowTravelingView
                 
-                TempTravelView()
+                tempTravelView
                 
                 Spacer(minLength: 16)
                 
@@ -99,85 +99,85 @@ struct TravelListView: View {
                         TabView(selection: $currentPage) {
                             ForEach(0..<travelCount, id: \.self) { index in
                                 NavigationLink(destination: TravelDetailView(), label: {
-                                ZStack(alignment: .top) {
-                                    Rectangle()
-                                        .foregroundColor(.clear)
-                                        .frame(width: 350, height: 137 + 46)
-                                    
-                                    Rectangle()
-                                        .foregroundColor(.clear)
-                                        .frame(width: 350, height: 137)
-                                        .background(
-                                            Image("testImage")
-                                                .resizable()
-                                                .aspectRatio(contentMode: .fill)
-                                            
-                                        )
-                                        .cornerRadius(10)
-                                    
-                                    Rectangle()
-                                        .foregroundColor(.clear)
-                                        .frame(width: 350, height: 137)
-                                        .background(
-                                            LinearGradient(
-                                                stops: [
-                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                    Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
-                                                ],
-                                                startPoint: UnitPoint(x: 0.5, y: 0),
-                                                endPoint: UnitPoint(x: 0.5, y: 1)
-                                            )
-                                        )
-                                        .cornerRadius(10)
-                                    
-                                    VStack(alignment: .leading) {
-                                        Spacer()
-                                      
-                                        Group {
-                                            Text("Day ")
-                                            +
-                                            Text("\(viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()))")
-                                        }
-                                        .font(.caption1)
-                                        .foregroundStyle(Color.white)
-                                        .opacity(0.75)
-                                        .padding(.leading, 16)
-                                      
-                                        Text(nowTravel?[index].name ?? "제목 미정")
-                                            .font(.display1)
-                                            .foregroundStyle(Color.white)
-                                            .padding(.leading, 16)
+                                    ZStack(alignment: .top) {
+                                        Rectangle()
+                                            .foregroundColor(.clear)
+                                            .frame(width: 350, height: 137 + 46)
                                         
-                                        HStack {
-                                            Group {
-                                                Text(nowTravel?[index].startDate ?? Date(), formatter: TravelListViewModel.dateFormatter) +
-                                                Text(" ~ ") +
-                                                Text(nowTravel?[index].endDate ?? Date(), formatter: TravelListViewModel.dateFormatter)
-                                            }
-                                            .font(.subhead2_2)
-                                            .foregroundStyle(Color.white.opacity(0.75))
-                                            .padding(.leading, 16)
-                                            
+                                        Rectangle()
+                                            .foregroundColor(.clear)
+                                            .frame(width: 350, height: 137)
+                                            .background(
+                                                Image("testImage")
+                                                    .resizable()
+                                                    .aspectRatio(contentMode: .fill)
+                                                
+                                            )
+                                            .cornerRadius(10)
+                                        
+                                        Rectangle()
+                                            .foregroundColor(.clear)
+                                            .frame(width: 350, height: 137)
+                                            .background(
+                                                LinearGradient(
+                                                    stops: [
+                                                        Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                        Gradient.Stop(color: .black.opacity(0.75), location: 1.00)
+                                                    ],
+                                                    startPoint: UnitPoint(x: 0.5, y: 0),
+                                                    endPoint: UnitPoint(x: 0.5, y: 1)
+                                                )
+                                            )
+                                            .cornerRadius(10)
+                                        
+                                        VStack(alignment: .leading) {
                                             Spacer()
                                             
-                                            HStack {
-                                                Image(systemName: "person.fill")
-                                                    .foregroundStyle(Color.white)
-                                                
-                                                Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? ["me"]))
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color.white)
-                                                
+                                            Group {
+                                                Text("Day ")
+                                                +
+                                                Text("\(viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()))")
                                             }
-                                            .padding(.trailing, 16)
+                                            .font(.caption1)
+                                            .foregroundStyle(Color.white)
+                                            .opacity(0.75)
+                                            .padding(.leading, 16)
+                                            
+                                            Text(nowTravel?[index].name ?? "제목 미정")
+                                                .font(.display1)
+                                                .foregroundStyle(Color.white)
+                                                .padding(.leading, 16)
+                                            
+                                            HStack {
+                                                Group {
+                                                    Text(nowTravel?[index].startDate ?? Date(), formatter: TravelListViewModel.dateFormatter) +
+                                                    Text(" ~ ") +
+                                                    Text(nowTravel?[index].endDate ?? Date(), formatter: TravelListViewModel.dateFormatter)
+                                                }
+                                                .font(.subhead2_2)
+                                                .foregroundStyle(Color.white.opacity(0.75))
+                                                .padding(.leading, 16)
+                                                
+                                                Spacer()
+                                                
+                                                HStack {
+                                                    Image(systemName: "person.fill")
+                                                        .foregroundStyle(Color.white)
+                                                    
+                                                    Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? ["me"]))
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white)
+                                                    
+                                                }
+                                                .padding(.trailing, 16)
+                                            }
+                                            
                                         }
+                                        .padding(.bottom, 16)
+                                        .frame(width: 350, height: 137)
                                         
                                     }
-                                    .padding(.bottom, 16)
-                                    .frame(width: 350, height: 137)
-                                    
-                                }
-                            })
+                                })
                             }
                         }
                         .frame(width: 350, height: 230)
@@ -210,50 +210,47 @@ struct TravelListView: View {
         return CGFloat(currentPage) * screenWidth
     }
     
-//    private var tempTravelView: some View {
-//        Rectangle()
-//            .frame(width: 250, height: 68)
-//    }
+    private var tempTravelView: some View {
+        // Travel의 "Default" 라는 이름의 여행이 길이가 1이상이면 임시 기록이 존재함
+        // 뷰모델에서 Default이름 가진 여행 fetch 필요
+        ZStack {
+            if defaultTravel?.count != 0 {
+                
+                EmptyView()
+                
+            } else {
+                HStack(alignment: .center, spacing: 20) {
+                    Image("dollar-circle")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 36, height: 36)
+                        .background(.white)
+                        .shadow(color: .black.opacity(0.25), radius: 1, x: 0, y: 0)
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("분류가 필요한 지출 내역 \(viewModel.defaultTravel.count)개")
+                            .font(.subhead2_1)
+                            .foregroundColor(Color.black)
+                        
+                        Text("최근 지출 ❌11,650원❌")
+                            .font(.caption2)
+                            .foregroundColor(Color.gray300)
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 15)
+                .frame(width: 350, alignment: .leading)
+                .background(Color(red: 0.96, green: 0.96, blue: 0.96))
+                .cornerRadius(10)
+            }
+        }
+    }
 }
 
 extension View {
     func getWidth() -> CGFloat {
         return UIScreen.main.bounds.width
-    }
-}
-
-struct TempTravelView: View {
-    @State var isTempTravelExist = true
-    
-    var body: some View {
-        if !isTempTravelExist {
-            Rectangle()
-                .frame(width: 250, height: 0)
-        } else {
-            HStack(alignment: .center, spacing: 45) {
-                Image("franceFlag")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 36, height: 36)
-                    .background(.white)
-                    .shadow(color: .black.opacity(0.25), radius: 1, x: 0, y: 0)
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("분류가 필요한 지출 내역 1개")
-                        .font(.subhead2_1)
-                        .foregroundColor(Color.black)
-                    
-                    Text("최근 지출 11,650원")
-                        .font(.caption2)
-                        .foregroundColor(Color.gray300)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 15)
-            .frame(width: 350, alignment: .leading)
-            .background(Color(red: 0.96, green: 0.96, blue: 0.96))
-            .cornerRadius(10)
-        }
     }
 }
 

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -24,7 +24,12 @@ struct UpcomingTravelView: View {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0 ..< travelCnt, id: \.self) { index in
                             VStack {
-                                NavigationLink(destination: TravelDetailView(), label: {
+                                NavigationLink(destination: TravelDetailView(travelName: upcomingTravel?[index].name ?? "",
+                                                                             startDate: upcomingTravel?[index].startDate ?? Date(),
+                                                                             endDate: upcomingTravel?[index].endDate ?? Date(),
+                                                                             dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: upcomingTravel?[index].startDate ?? Date()),
+                                                                             participantCnt: upcomingTravel?[index].participantArray?.count ?? 0,
+                                                                             participantArr: upcomingTravel?[index].participantArray ?? []), label: {
                                     ZStack {
                                         Image("basicImage")
                                             .resizable()
@@ -78,7 +83,12 @@ struct UpcomingTravelView: View {
                                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                                         ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
                                             VStack {
-                                              NavigationLink(destination: TravelDetailView(), label: {
+                                              NavigationLink(destination: TravelDetailView(travelName: upcomingTravel?[index].name ?? "",
+                                                                                           startDate: upcomingTravel?[index].startDate ?? Date(),
+                                                                                           endDate: upcomingTravel?[index].endDate ?? Date(),
+                                                                                           dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: upcomingTravel?[index].startDate ?? Date()),
+                                                                                           participantCnt: upcomingTravel?[index].participantArray?.count ?? 0,
+                                                                                           participantArr: upcomingTravel?[index].participantArray ?? []), label: {
                                                 ZStack {
                                                     Image("basicImage")
                                                         .resizable()

--- a/UMM/ViewModel/PreviousTravelViewModel.swift
+++ b/UMM/ViewModel/PreviousTravelViewModel.swift
@@ -41,4 +41,10 @@ class PreviousTravelViewModel: ObservableObject {
         
         return formatter
     }()
+    
+    func differenceBetweenToday(today: Date, startDate: Date) -> Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.day], from: startDate, to: today)
+        return components.day ?? 0
+    }
 }

--- a/UMM/ViewModel/TravelDetailViewModel.swift
+++ b/UMM/ViewModel/TravelDetailViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  TravelDetailViewModel.swift
+//  UMM
+//
+//  Created by GYURI PARK on 2023/10/27.
+//
+
+import Foundation
+
+class TravelDetailViewModel: ObservableObject {
+    
+    static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "YY.MM.dd (E)"
+        
+        return formatter
+    }()
+}

--- a/UMM/ViewModel/UpcomingTravelViewModel.swift
+++ b/UMM/ViewModel/UpcomingTravelViewModel.swift
@@ -42,4 +42,9 @@ class UpcomingTravelViewModel: ObservableObject {
         return formatter
     }()
 
+    func differenceBetweenToday(today: Date, startDate: Date) -> Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.day], from: startDate, to: today)
+        return components.day ?? 0
+    }
 }


### PR DESCRIPTION
## 👀 이슈
- #122 

## 💡 작업 내용
- TravelDetailView에 데이터를 추가합니다. (국가 관련 제외)
- HIFI보며 정렬 작업

## 📱스크린샷
<img width="30%" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/f85fefb2-31f4-473e-b927-6620e76ff628">


## 🚨 참고 사항
- 추후 국가 인덱스를 추가할 경우 1. 배경에 들어갈 사진 2. 국기 이미지 3. 국가 이름 데이터를 추가할 예정

## (Optional) 🤔 고민한 점
- Detail 뷰의 변경 사항이 TravelListView에 반영되어야 할 상황에 대비해 데이터 전달과정에서 이니셜라이저는 사용하지 않았습니다.