### PR TITLE
🎨[#142] ManualRecordView를 어느 정도 완성합니다.

### DIFF
--- a/UMM/View/Modal/CountryChoiceModal.swift
+++ b/UMM/View/Modal/CountryChoiceModal.swift
@@ -99,6 +99,7 @@ struct CountryChoiceModal: View {
                         }
                         .onTapGesture {
                             chosenCountry = currentCountry
+                            countryIsModified = true
                         }
                     }
                 }

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -13,7 +13,7 @@ struct ManualRecordView: View {
     var recordViewModel: RecordViewModel
     @Environment(\.dismiss) var dismiss
     let viewContext = PersistenceController.shared.container.viewContext
-    let handler = ExchangeRateHandler.shared
+    let exchangeHandler = ExchangeRateHandler.shared
     let fraction0NumberFormatter = NumberFormatter()
 
     var body: some View {
@@ -43,8 +43,14 @@ struct ManualRecordView: View {
 //                    }
                     
                     Spacer()
-                        .frame(height: 25)
+                        .frame(height: 150)
                 }
+            }
+            VStack(spacing: 0) {
+                Spacer()
+                autoSaveTextView
+                Spacer()
+                    .frame(height: 16)
                 saveButtonView
             }
         }
@@ -62,14 +68,6 @@ struct ManualRecordView: View {
         .sheet(isPresented: $viewModel.countryChoiceModalIsShown) {
             CountryChoiceModal(chosenCountry: $viewModel.country, countryIsModified: $viewModel.countryIsModified, countryArray: viewModel.otherCountryCandidateArray, currentCountry: viewModel.currentCountry)
                 .presentationDetents([.height(289 - 34)])
-        }
-        .onTapGesture {
-            if viewModel.visibleNewNameOfParticipant.count > 0 {
-                viewModel.additionalParticipantTupleArray.append((viewModel.visibleNewNameOfParticipant, true))
-            }
-            DispatchQueue.main.async {
-                viewModel.visibleNewNameOfParticipant = ""
-            }
         }
         .onAppear {
             viewModel.getLocation()
@@ -98,11 +96,42 @@ struct ManualRecordView: View {
             if viewModel.payAmount == -1 || viewModel.currency == .unknown {
                 viewModel.payAmountInWon = -1
             } else {
-                viewModel.payAmountInWon = viewModel.payAmount * (handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(viewModel.currency.rawValue))) ?? -1)
+                viewModel.payAmountInWon = viewModel.payAmount * (exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(viewModel.currency.rawValue))) ?? -1)
             }
+            
             // MARK: - NumberFormatter
+            
             fraction0NumberFormatter.numberStyle = .decimal
             fraction0NumberFormatter.maximumFractionDigits = 0
+            
+            // MARK: - timer
+            
+            if viewModel.recordButtonIsUsed && (viewModel.payAmount != -1 || viewModel.info != nil) {
+                viewModel.secondCounter = 8
+                viewModel.autoSaveTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+                    if let secondCounter = viewModel.secondCounter {
+                        if secondCounter > 1 {
+                            viewModel.secondCounter! -= 1
+                        } else {
+                            if viewModel.payAmount != -1 || viewModel.info != nil {
+                                viewModel.secondCounter = nil
+                                viewModel.save()
+                                if viewModel.chosenTravel != nil {
+                                    recordViewModel.setChosenTravel(as: viewModel.chosenTravel!)
+                                }
+                                self.dismiss()
+                                timer.invalidate()
+                            } else {
+                                viewModel.secondCounter = nil
+                                timer.invalidate()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onDisappear {
+            viewModel.autoSaveTimer?.invalidate()
         }
     }
     
@@ -110,7 +139,9 @@ struct ManualRecordView: View {
         viewModel = ManualRecordViewModel()
         recordViewModel = prevViewModel
         
-        if prevViewModel.needToFill {
+        viewModel.recordButtonIsUsed = prevViewModel.recordButtonIsFocused
+        
+        if viewModel.recordButtonIsUsed {
             viewModel.payAmount = prevViewModel.payAmount
             viewModel.visiblePayAmount = viewModel.payAmount == -1 ? "" : String(viewModel.payAmount)
             viewModel.info = prevViewModel.info
@@ -162,7 +193,7 @@ struct ManualRecordView: View {
         if viewModel.payAmount == -1 || viewModel.currency == .unknown {
             viewModel.payAmountInWon = -1
         } else {
-            viewModel.payAmountInWon = viewModel.payAmount * (handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(viewModel.currency.rawValue))) ?? -1) // ^^^
+            viewModel.payAmountInWon = viewModel.payAmount * (exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(viewModel.currency.rawValue))) ?? -1) // ^^^
         }
         viewModel.soundRecordFileName = prevViewModel.soundRecordFileName
     }
@@ -263,6 +294,7 @@ struct ManualRecordView: View {
                 Spacer()
                 Button {
                     print("소리 재생 버튼")
+                    viewModel.autoSaveTimer?.invalidate()
                 } label: {
                     Circle() // replace ^^^
                         .foregroundStyle(.gray200)
@@ -313,16 +345,6 @@ struct ManualRecordView: View {
                             .padding(.horizontal, 8)
                             .padding(.vertical, 6)
                     }
-                    
-//                    Spacer()
-//                    Button {
-//                        print("소비 내역 수정 버튼")
-//                    } label: {
-//                        Image("manualRecordPencil")
-//                            .resizable()
-//                            .scaledToFit()
-//                            .frame(width: 16, height: 16)
-//                    }
                 }
                 
                 HStack(spacing: 0) {
@@ -360,6 +382,7 @@ struct ManualRecordView: View {
                         .frame(width: 16, height: 16)
                         .onTapGesture {
                             print("카테고리 수정 버튼")
+                            viewModel.autoSaveTimer?.invalidate()
                             viewModel.categoryChoiceModalIsShown = true
                         }
                     
@@ -403,6 +426,7 @@ struct ManualRecordView: View {
                     }
                     .onTapGesture {
                         print("현금 선택 버튼")
+                        viewModel.autoSaveTimer?.invalidate()
                         if viewModel.paymentMethod == .cash {
                             viewModel.paymentMethod = .unknown
                         } else {
@@ -442,6 +466,7 @@ struct ManualRecordView: View {
                     }
                     .onTapGesture {
                         print("카드 선택 버튼")
+                        viewModel.autoSaveTimer?.invalidate()
                         if viewModel.paymentMethod == .card {
                             viewModel.paymentMethod = .unknown
                         } else {
@@ -493,6 +518,7 @@ struct ManualRecordView: View {
                         .frame(width: 16, height: 16)
                         .onTapGesture {
                             print("여행 선택 버튼")
+                            viewModel.autoSaveTimer?.invalidate()
                             viewModel.travelChoiceModalIsShown = true
                         }
                     
@@ -507,78 +533,11 @@ struct ManualRecordView: View {
                     }
                     ScrollView(.horizontal) {
                         HStack(spacing: 6) {
-                            ForEach(0..<(viewModel.participantTupleArray.count + viewModel.additionalParticipantTupleArray.count), id: \.self) { index in
-                                let isBasicParticipant = index < viewModel.participantTupleArray.count
-                                let tuple: (String, Bool) = isBasicParticipant ? viewModel.participantTupleArray[index] : viewModel.additionalParticipantTupleArray[index - viewModel.participantTupleArray.count]
-                                
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .foregroundStyle(tuple.1 == true ? Color(0x333333) : .gray100) // 색상 디자인 시스템 형식으로 고치기 ^^^
-                                        .layoutPriority(-1)
-                                    
-                                    // 높이 설정용 히든 뷰
-                                    Text("금")
-                                        .lineLimit(1)
-                                        .font(.subhead2_2)
-                                        .padding(.vertical, 6)
-                                        .hidden()
-                                    
-                                    HStack(spacing: 4) {
-                                        if tuple.0 == "나" {
-                                            Text("me")
-                                                .lineLimit(1)
-                                                .foregroundStyle(tuple.1 ? .gray200 : .gray300)
-                                                .font(.subhead2_1)
-                                        }
-                                        Text(tuple.0)
-                                            .lineLimit(1)
-                                            .foregroundStyle(tuple.1 ? .white : .gray300)
-                                            .font(.subhead2_2)
-                                    }
-                                    .padding(.vertical, 6)
-                                    .padding(.horizontal, 12)
-                                }
-                                .onTapGesture {
-                                    print("참여 인원(\(tuple.0)) 참여 여부 설정 버튼")
-                                    if isBasicParticipant {
-                                        viewModel.participantTupleArray[index].1.toggle()
-                                    } else {
-                                        viewModel.additionalParticipantTupleArray[index - viewModel.participantTupleArray.count].1.toggle()
-                                    }
-                                }
+                            if viewModel.participantTupleArray.count > 0 {
+                                ParticipantArrayView(participantTupleArray: $viewModel.participantTupleArray)
+                            } else {
+                                EmptyView()
                             }
-                            
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 6)
-                                    .foregroundStyle(.gray100)
-                                    .layoutPriority(-1)
-                                
-                                // 높이 설정용 히든 뷰
-                                Text("금")
-                                    .lineLimit(1)
-                                    .font(.subhead2_2)
-                                    .padding(.horizontal, 8)
-                                    .padding(.vertical, 6)
-                                    .hidden()
-                                
-                                TextField("╋", text: $viewModel.visibleNewNameOfParticipant) {
-                                    print("asdfasdf")
-                                    if viewModel.visibleNewNameOfParticipant.count > 0 {
-                                        viewModel.additionalParticipantTupleArray.append((viewModel.visibleNewNameOfParticipant, true))
-                                    }
-                                    DispatchQueue.main.async {
-                                        viewModel.visibleNewNameOfParticipant = ""
-                                    }
-                                }
-                                .lineLimit(1)
-                                .foregroundStyle(.gray300)
-                                .font(.subhead2_2)
-                                .padding(.horizontal, 8)
-                                .tint(.mainPink)
-                            }
-                            
-                            Spacer()
-                                .frame(width: 30)
                         }
                     }
                     .scrollIndicators(.never)
@@ -612,6 +571,7 @@ struct ManualRecordView: View {
                         .frame(width: 16, height: 16)
                         .onTapGesture {
                             print("지출 일시 수정 버튼")
+                            viewModel.autoSaveTimer?.invalidate()
                         }
                 }
                 VStack(spacing: 10) {
@@ -642,9 +602,16 @@ struct ManualRecordView: View {
                                 }
                                 .frame(width: 24, height: 24)
                                 
-                                Text(viewModel.countryExpression + " " + viewModel.locationExpression)
-                                    .foregroundStyle(.black)
-                                    .font(.subhead2_2)
+                                if !viewModel.countryIsModified {
+                                    Text(viewModel.countryExpression + " " + viewModel.locationExpression)
+                                        .foregroundStyle(.black)
+                                        .font(.subhead2_2)
+                                } else {
+                                    Text(viewModel.countryExpression)
+                                        .foregroundStyle(.black)
+                                        .font(.subhead2_2)
+                                }
+                                
                             }
                         }
                         
@@ -656,6 +623,7 @@ struct ManualRecordView: View {
                             .frame(width: 16, height: 16)
                             .onTapGesture {
                                 print("지출 위치 수정 버튼")
+                                viewModel.autoSaveTimer?.invalidate()
                                 viewModel.countryChoiceModalIsShown = true
                             }
                     }
@@ -703,11 +671,112 @@ struct ManualRecordView: View {
         }
     }
     
+    private var autoSaveTextView: some View {
+        Group {
+            if let secondCounter = viewModel.secondCounter {
+                if secondCounter > 0 && secondCounter <= 3 {
+                    Text("\(secondCounter)초 후 자동 저장")
+                        .foregroundStyle(.gray300)
+                        .font(.body2)
+                } else {
+                    EmptyView()
+                }
+            } else {
+                EmptyView()
+            }
+        }
+    }
+    
     private var saveButtonView: some View {
-        LargeButtonActive(title: "저장하기") {
-            viewModel.save()
-            recordViewModel.setChosenTravel(as: viewModel.chosenTravel ?? Travel())
-            dismiss()
+        ZStack {
+            LargeButtonActive(title: "저장하기") {
+                viewModel.save()
+                var defaultTravel = Travel()
+                do {
+                    defaultTravel = try viewContext.fetch(Travel.fetchRequest()).filter { $0.name == "Default" }.first ?? Travel()
+                } catch {
+                    print("error fetching default travel: \(error.localizedDescription)")
+                }
+                recordViewModel.setChosenTravel(as: viewModel.chosenTravel ?? defaultTravel)
+                dismiss()
+            }
+            .opacity((viewModel.payAmount != -1 || viewModel.info != nil) ? 1 : 0.0000001)
+            .allowsHitTesting(viewModel.payAmount != -1 || viewModel.info != nil)
+            
+            LargeButtonUnactive(title: "저장하기") { }
+                .opacity((viewModel.payAmount != -1 || viewModel.info != nil) ? 0.0000001 : 1)
+                .allowsHitTesting(!(viewModel.payAmount != -1 || viewModel.info != nil))
+        }
+    }
+}
+
+struct ParticipantArrayView: View {
+    @Binding var participantTupleArray: [(name: String, isOn: Bool)]
+    
+    let buttonCountInARow = 3
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(0..<((participantTupleArray.count - 1) / buttonCountInARow + 1), id: \.self) { rowNum in
+                let diff = participantTupleArray.count - 1 - rowNum * buttonCountInARow
+                if diff == 0 {
+                    HStack(spacing: 6) {
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
+                    }
+                } else if diff == 1 {
+                    HStack(spacing: 6) {
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 1)
+                    }
+                } else {
+                    HStack(spacing: 6) {
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 1)
+                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 2)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ParticipantToggleView: View {
+    
+    @Binding var participantTupleArray: [(name: String, isOn: Bool)]
+    let index: Int
+    
+    var body: some View {
+        let tuple = participantTupleArray[index]
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .foregroundStyle(tuple.isOn ? Color(0x333333) : .gray100) // 색상 디자인 시스템 형식으로 고치기 ^^^
+                .layoutPriority(-1)
+            
+            // 높이 설정용 히든 뷰
+            Text("금")
+                .lineLimit(1)
+                .font(.subhead2_2)
+                .padding(.vertical, 6)
+                .hidden()
+            
+            HStack(spacing: 4) {
+                if tuple.name == "나" {
+                    Text("me")
+                        .lineLimit(1)
+                        .foregroundStyle(tuple.isOn ? .gray200 : .gray300)
+                        .font(.subhead2_1)
+                }
+                Text(tuple.0)
+                    .lineLimit(1)
+                    .foregroundStyle(tuple.isOn ? .white : .gray300)
+                    .font(.subhead2_2)
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 12)
+        }
+        .onTapGesture {
+            print("참여 인원(\(tuple.name)) 참여 여부 설정 버튼")
+            participantTupleArray[index].isOn.toggle()
         }
     }
 }

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -20,10 +20,9 @@ struct ManualRecordView: View {
         ZStack {
             Color(.white)
             VStack(spacing: 0) {
-                titleBlockView
                 ScrollView {
                     Spacer()
-                        .frame(height: 45)
+                        .frame(height: 107 - 9 + 45)
                     payAmountBlockView
                     Spacer()
                         .frame(height: 64)
@@ -33,15 +32,6 @@ struct ManualRecordView: View {
                         .padding(.vertical, 20)
                         .padding(.horizontal, 20)
                     notInStringPropertyBlockView
-                    
-//                    VStack {
-//                        Text("Address Information:")
-//                        Text("Name: \(viewModel.placemark?.name ?? "N/A")")
-//                        Text("Locality: \(viewModel.placemark?.locality ?? "N/A")")
-//                        Text("Administrative Area: \(viewModel.placemark?.administrativeArea ?? "N/A")")
-//                        Text("Country: \(viewModel.placemark?.country ?? "N/A")")
-//                    }
-                    
                     Spacer()
                         .frame(height: 150)
                 }
@@ -56,7 +46,30 @@ struct ManualRecordView: View {
         }
         .ignoresSafeArea()
         .toolbar(.hidden, for: .tabBar)
+        .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden()
+        .toolbarBackground(.white, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    viewModel.autoSaveTimer?.invalidate()
+                    viewModel.secondCounter = nil
+                    viewModel.backButtonAlertIsShown = true
+                    print("back button tapped")
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .imageScale(.large)
+                        .foregroundColor(Color.black)
+                }
+            }
+            
+            ToolbarItem(placement: .principal) {
+                Text("기록 완료")
+                    .foregroundStyle(.black)
+                    .font(.subhead2_1)
+            }
+        }
         .sheet(isPresented: $viewModel.travelChoiceModalIsShown) {
             TravelChoiceInRecordModal(chosenTravel: $viewModel.chosenTravel)
                 .presentationDetents([.height(289 - 34)])
@@ -68,6 +81,20 @@ struct ManualRecordView: View {
         .sheet(isPresented: $viewModel.countryChoiceModalIsShown) {
             CountryChoiceModal(chosenCountry: $viewModel.country, countryIsModified: $viewModel.countryIsModified, countryArray: viewModel.otherCountryCandidateArray, currentCountry: viewModel.currentCountry)
                 .presentationDetents([.height(289 - 34)])
+        }
+        .alert(Text("화면 전환 안내"), isPresented: $viewModel.backButtonAlertIsShown) {
+            Button {
+                viewModel.backButtonAlertIsShown = false
+            } label: {
+                Text("아니오")
+            }
+            Button {
+                dismiss()
+                viewModel.backButtonAlertIsShown = false
+            } label: {
+                Text("예")
+            }
+        } message: {Text("현재 화면의 정보를 모두 초기화하고 이전 화면으로 돌아가시겠습니까?")
         }
         .onAppear {
             viewModel.getLocation()
@@ -144,7 +171,7 @@ struct ManualRecordView: View {
         
         if viewModel.recordButtonIsUsed {
             viewModel.payAmount = prevViewModel.payAmount
-            viewModel.visiblePayAmount = viewModel.payAmount == -1 ? "" : String(viewModel.payAmount)
+            viewModel.visiblePayAmount = viewModel.payAmount == -1 ? "" : String(viewModel.payAmount) // 소숫점 아래 없는 visiblePayAmount에 ".0" 더해지는 문제는 여기서 해결하기 ^^^
             viewModel.info = prevViewModel.info
             viewModel.visibleInfo = viewModel.info == nil ? "" : viewModel.info!
             viewModel.category = prevViewModel.infoCategory

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -614,49 +614,87 @@ struct ManualRecordView: View {
                             print("지출 일시 수정 버튼")
                         }
                 }
-                HStack(spacing: 0) {
-                    ZStack(alignment: .leading) {
-                        Spacer()
-                            .frame(width: 116, height: 1)
-                        Text("지출 위치")
-                            .foregroundStyle(.gray300)
-                            .font(.caption2)
-                    }
-                    ZStack {
-                        // 높이 설정용 히든 뷰
-                        Text("금")
-                            .lineLimit(1)
-                            .font(.subhead2_2)
-                            .padding(.vertical, 6)
-                            .hidden()
-                        
-                        HStack(spacing: 8) {
-                            ZStack {
-                                Image(viewModel.country.flagImageString) // 이뉴머레이션 못 쓰면 수정해야 함
-                                    .resizable()
-                                    .scaledToFit()
-                                
-                                Circle()
-                                    .strokeBorder(.gray200, lineWidth: 1.0)
-                            }
-                            .frame(width: 24, height: 24)
-                          
-                            Text(viewModel.countryExpression + " " + viewModel.locationExpression)
-                                .foregroundStyle(.black)
+                VStack(spacing: 10) {
+                    HStack(spacing: 0) {
+                        ZStack(alignment: .leading) {
+                            Spacer()
+                                .frame(width: 116, height: 1)
+                            Text("지출 위치")
+                                .foregroundStyle(.gray300)
+                                .font(.caption2)
+                        }
+                        ZStack {
+                            // 높이 설정용 히든 뷰
+                            Text("금")
+                                .lineLimit(1)
                                 .font(.subhead2_2)
+                                .padding(.vertical, 6)
+                                .hidden()
+                            
+                            HStack(spacing: 8) {
+                                ZStack {
+                                    Image(viewModel.country.flagImageString) // 이뉴머레이션 못 쓰면 수정해야 함
+                                        .resizable()
+                                        .scaledToFit()
+                                    
+                                    Circle()
+                                        .strokeBorder(.gray200, lineWidth: 1.0)
+                                }
+                                .frame(width: 24, height: 24)
+                                
+                                Text(viewModel.countryExpression + " " + viewModel.locationExpression)
+                                    .foregroundStyle(.black)
+                                    .font(.subhead2_2)
+                            }
                         }
+                        
+                        Spacer()
+                        
+                        Image("manualRecordDownChevron")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 16, height: 16)
+                            .onTapGesture {
+                                print("지출 위치 수정 버튼")
+                                viewModel.countryChoiceModalIsShown = true
+                            }
                     }
                     
-                    Spacer()
-                    
-                    Image("manualRecordDownChevron")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 16, height: 16)
-                        .onTapGesture {
-                            print("지출 위치 수정 버튼")
-                            viewModel.countryChoiceModalIsShown = true
+                    if viewModel.countryIsModified {
+                        HStack(spacing: 0) {
+                            ZStack(alignment: .leading) {
+                                Spacer()
+                                    .frame(width: 116, height: 1)
+                                
+                                Text(" ")
+                                    .foregroundStyle(.gray300)
+                                    .font(.caption2)
+                            }
+                            ZStack(alignment: .leading) {
+                                //                        높이 설정용 히든 뷰
+                                ZStack {
+                                    Text("금")
+                                        .foregroundStyle(.black)
+                                        .font(.subhead2_1)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 6)
+                                }
+                                .hidden()
+                                
+                                RoundedRectangle(cornerRadius: 6)
+                                    .foregroundStyle(.gray100)
+                                    .layoutPriority(-1)
+                                
+                                TextField("-", text: $viewModel.locationExpression)
+                                    .lineLimit(nil)
+                                    .foregroundStyle(.black)
+                                    .font(.body3)
+                                    .tint(.mainPink)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 6)
+                            }
                         }
+                    }
                 }
                 
             }

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -300,6 +300,10 @@ struct ManualRecordView: View {
                                     Text(currency.title + " " + currency.officialSymbol)
                                 }
                             }
+                            .onTapGesture {
+                                viewModel.autoSaveTimer?.invalidate()
+                                viewModel.secondCounter = nil
+                            }
                             
                             ZStack {
                                 RoundedRectangle(cornerRadius: 6)

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -14,6 +14,7 @@ struct ManualRecordView: View {
     @Environment(\.dismiss) var dismiss
     let viewContext = PersistenceController.shared.container.viewContext
     let handler = ExchangeRateHandler.shared
+    let fraction0NumberFormatter = NumberFormatter()
 
     var body: some View {
         ZStack {
@@ -99,6 +100,9 @@ struct ManualRecordView: View {
             } else {
                 viewModel.payAmountInWon = viewModel.payAmount * (handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(viewModel.currency.rawValue))) ?? -1)
             }
+            // MARK: - NumberFormatter
+            fraction0NumberFormatter.numberStyle = .decimal
+            fraction0NumberFormatter.maximumFractionDigits = 0
         }
     }
     
@@ -230,7 +234,7 @@ struct ManualRecordView: View {
                                 RoundedRectangle(cornerRadius: 6)
                                     .foregroundStyle(.gray100)
                                     .layoutPriority(-1)
-                                Text(viewModel.currency.title + " " + viewModel.currency.officialSymbol) // viewModel.currency에 연동하기 ^^^
+                                Text(viewModel.currency.title + " " + viewModel.currency.officialSymbol)
                                     .foregroundStyle(.gray400)
                                     .font(.display2)
                                     .padding(.vertical, 4)
@@ -245,9 +249,15 @@ struct ManualRecordView: View {
                             .foregroundStyle(.gray300)
                             .font(.caption2)
                     } else {
-                        Text("(" + String(format: "%.2f", viewModel.payAmountInWon) + "원" + ")")
-                            .foregroundStyle(.gray300)
-                            .font(.caption2)
+                        if let formattedString = fraction0NumberFormatter.string(from: NSNumber(value: viewModel.payAmountInWon)) {
+                            Text("(" + formattedString + "원" + ")")
+                                .foregroundStyle(.gray300)
+                                .font(.caption2)
+                        } else {
+                            Text("( - 원)")
+                                .foregroundStyle(.gray300)
+                                .font(.caption2)
+                        }
                     }
                 }
                 Spacer()

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -132,6 +132,7 @@ struct ManualRecordView: View {
         }
         .onDisappear {
             viewModel.autoSaveTimer?.invalidate()
+            viewModel.secondCounter = nil
         }
     }
     
@@ -252,6 +253,10 @@ struct ManualRecordView: View {
                                 .keyboardType(.decimalPad)
                                 .layoutPriority(-1)
                                 .tint(.mainPink)
+                                .onTapGesture {
+                                    viewModel.autoSaveTimer?.invalidate()
+                                    viewModel.secondCounter = nil
+                                }
                         }
                         
                         ZStack {
@@ -295,6 +300,7 @@ struct ManualRecordView: View {
                 Button {
                     print("소리 재생 버튼")
                     viewModel.autoSaveTimer?.invalidate()
+                    viewModel.secondCounter = nil
                 } label: {
                     Circle() // replace ^^^
                         .foregroundStyle(.gray200)
@@ -344,6 +350,10 @@ struct ManualRecordView: View {
                             .tint(.mainPink)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 6)
+                            .onTapGesture {
+                                viewModel.autoSaveTimer?.invalidate()
+                                viewModel.secondCounter = nil
+                            }
                     }
                 }
                 
@@ -383,6 +393,7 @@ struct ManualRecordView: View {
                         .onTapGesture {
                             print("카테고리 수정 버튼")
                             viewModel.autoSaveTimer?.invalidate()
+                            viewModel.secondCounter = nil
                             viewModel.categoryChoiceModalIsShown = true
                         }
                     
@@ -427,6 +438,7 @@ struct ManualRecordView: View {
                     .onTapGesture {
                         print("현금 선택 버튼")
                         viewModel.autoSaveTimer?.invalidate()
+                        viewModel.secondCounter = nil
                         if viewModel.paymentMethod == .cash {
                             viewModel.paymentMethod = .unknown
                         } else {
@@ -467,6 +479,7 @@ struct ManualRecordView: View {
                     .onTapGesture {
                         print("카드 선택 버튼")
                         viewModel.autoSaveTimer?.invalidate()
+                        viewModel.secondCounter = nil
                         if viewModel.paymentMethod == .card {
                             viewModel.paymentMethod = .unknown
                         } else {
@@ -519,6 +532,7 @@ struct ManualRecordView: View {
                         .onTapGesture {
                             print("여행 선택 버튼")
                             viewModel.autoSaveTimer?.invalidate()
+                            viewModel.secondCounter = nil
                             viewModel.travelChoiceModalIsShown = true
                         }
                     
@@ -534,7 +548,7 @@ struct ManualRecordView: View {
                     ScrollView(.horizontal) {
                         HStack(spacing: 6) {
                             if viewModel.participantTupleArray.count > 0 {
-                                ParticipantArrayView(participantTupleArray: $viewModel.participantTupleArray)
+                                ParticipantArrayView(viewModel: viewModel)
                             } else {
                                 EmptyView()
                             }
@@ -572,6 +586,7 @@ struct ManualRecordView: View {
                         .onTapGesture {
                             print("지출 일시 수정 버튼")
                             viewModel.autoSaveTimer?.invalidate()
+                            viewModel.secondCounter = nil
                         }
                 }
                 VStack(spacing: 10) {
@@ -624,6 +639,7 @@ struct ManualRecordView: View {
                             .onTapGesture {
                                 print("지출 위치 수정 버튼")
                                 viewModel.autoSaveTimer?.invalidate()
+                                viewModel.secondCounter = nil
                                 viewModel.countryChoiceModalIsShown = true
                             }
                     }
@@ -660,6 +676,10 @@ struct ManualRecordView: View {
                                     .tint(.mainPink)
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 6)
+                                    .onTapGesture {
+                                        viewModel.autoSaveTimer?.invalidate()
+                                        viewModel.secondCounter = nil
+                                    }
                             }
                         }
                     }
@@ -711,28 +731,28 @@ struct ManualRecordView: View {
 }
 
 struct ParticipantArrayView: View {
-    @Binding var participantTupleArray: [(name: String, isOn: Bool)]
+    @ObservedObject var viewModel: ManualRecordViewModel
     
     let buttonCountInARow = 3
     
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            ForEach(0..<((participantTupleArray.count - 1) / buttonCountInARow + 1), id: \.self) { rowNum in
-                let diff = participantTupleArray.count - 1 - rowNum * buttonCountInARow
+            ForEach(0..<((viewModel.participantTupleArray.count - 1) / buttonCountInARow + 1), id: \.self) { rowNum in
+                let diff = viewModel.participantTupleArray.count - 1 - rowNum * buttonCountInARow
                 if diff == 0 {
                     HStack(spacing: 6) {
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow)
                     }
                 } else if diff == 1 {
                     HStack(spacing: 6) {
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 1)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow + 1)
                     }
                 } else {
                     HStack(spacing: 6) {
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow)
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 1)
-                        ParticipantToggleView(participantTupleArray: $participantTupleArray, index: rowNum * buttonCountInARow + 2)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow + 1)
+                        ParticipantToggleView(viewModel: viewModel, index: rowNum * buttonCountInARow + 2)
                     }
                 }
             }
@@ -741,12 +761,11 @@ struct ParticipantArrayView: View {
 }
 
 struct ParticipantToggleView: View {
-    
-    @Binding var participantTupleArray: [(name: String, isOn: Bool)]
+    @ObservedObject var viewModel: ManualRecordViewModel
     let index: Int
     
     var body: some View {
-        let tuple = participantTupleArray[index]
+        let tuple = viewModel.participantTupleArray[index]
         ZStack {
             RoundedRectangle(cornerRadius: 6)
                 .foregroundStyle(tuple.isOn ? Color(0x333333) : .gray100) // 색상 디자인 시스템 형식으로 고치기 ^^^
@@ -776,7 +795,9 @@ struct ParticipantToggleView: View {
         }
         .onTapGesture {
             print("참여 인원(\(tuple.name)) 참여 여부 설정 버튼")
-            participantTupleArray[index].isOn.toggle()
+            viewModel.autoSaveTimer?.invalidate()
+            viewModel.secondCounter = nil
+            viewModel.participantTupleArray[index].isOn.toggle()
         }
     }
 }

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -46,30 +46,10 @@ struct ManualRecordView: View {
         }
         .ignoresSafeArea()
         .toolbar(.hidden, for: .tabBar)
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden()
         .toolbarBackground(.white, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button {
-                    viewModel.autoSaveTimer?.invalidate()
-                    viewModel.secondCounter = nil
-                    viewModel.backButtonAlertIsShown = true
-                    print("back button tapped")
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .imageScale(.large)
-                        .foregroundColor(Color.black)
-                }
-            }
-            
-            ToolbarItem(placement: .principal) {
-                Text("기록 완료")
-                    .foregroundStyle(.black)
-                    .font(.subhead2_1)
-            }
-        }
+        .navigationTitle("기록 완료")
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: backButtonView)
         .sheet(isPresented: $viewModel.travelChoiceModalIsShown) {
             TravelChoiceInRecordModal(chosenTravel: $viewModel.chosenTravel)
                 .presentationDetents([.height(289 - 34)])
@@ -234,38 +214,17 @@ struct ManualRecordView: View {
         viewModel.soundRecordFileName = prevViewModel.soundRecordFileName
     }
     
-    private var titleBlockView: some View {
-        ZStack {
-            Color(.white)
-                .layoutPriority(-1)
-            HStack(spacing: 0) {
-                Spacer()
-                    .frame(width: 20)
-                ZStack {
-                    HStack(spacing: 0) {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image("manualRecordTitleLeftChevron")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 24, height: 24)
-                        }
-                        
-                        Spacer()
-                    }
-                    
-                    Text("기록 완료")
-                        .foregroundStyle(.black)
-                        .font(.subhead2_1)
-                }
-                
-                Spacer()
-                    .frame(width: 20)
-            }
+    private var backButtonView: some View {
+        Button {
+            viewModel.autoSaveTimer?.invalidate()
+            viewModel.secondCounter = nil
+            viewModel.backButtonAlertIsShown = true
+            print("back button tapped")
+        } label: {
+            Image(systemName: "chevron.left")
+                .imageScale(.large)
+                .foregroundColor(Color.black)
         }
-        .padding(.top, 68)
-        .padding(.bottom, 15)
     }
     
     private var payAmountBlockView: some View {

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -171,7 +171,15 @@ struct ManualRecordView: View {
         
         if viewModel.recordButtonIsUsed {
             viewModel.payAmount = prevViewModel.payAmount
-            viewModel.visiblePayAmount = viewModel.payAmount == -1 ? "" : String(viewModel.payAmount) // 소숫점 아래 없는 visiblePayAmount에 ".0" 더해지는 문제는 여기서 해결하기 ^^^
+            if viewModel.payAmount == -1 {
+                viewModel.visiblePayAmount = ""
+            } else {
+                if abs(viewModel.payAmount - Double(Int(viewModel.payAmount))) < 0.0000001 {
+                    viewModel.visiblePayAmount = String(format: "%.0f", viewModel.payAmount)
+                } else {
+                    viewModel.visiblePayAmount = String(viewModel.payAmount)
+                }
+            }
             viewModel.info = prevViewModel.info
             viewModel.visibleInfo = viewModel.info == nil ? "" : viewModel.info!
             viewModel.category = prevViewModel.infoCategory

--- a/UMM/View/Record/RecordView.swift
+++ b/UMM/View/Record/RecordView.swift
@@ -17,22 +17,18 @@ struct RecordView: View {
     @State private var isDetectingPress_showOnButton = false {
         didSet {
             if isDetectingPress_showOnButton {
-                print("isDetectingPress_showOnButton is now true")
                 withAnimation(.linear(duration: 0.01).delay(0.01)) {
                     isDetectingPress_letButtonBigger = true
                 }
-                print("isDetectingPress_letButtonBigger is now true")
             }
         }
     }
     @State private var isDetectingPress_letButtonBigger = false {
         didSet {
             if !isDetectingPress_letButtonBigger {
-                print("isDetectingPress_letButtonBigger is now false")
                 withAnimation(.linear(duration: 0.01).delay(recordButtonAnimationLength)) {
                     isDetectingPress_showOnButton = false
                 }
-                print("isDetectingPress_showOnButton is now false")
             }
         }
     }
@@ -61,7 +57,7 @@ struct RecordView: View {
             .ignoresSafeArea()
             .onAppear {
                 viewModel.resetInStringProperties()
-                viewModel.needToFill = true
+                viewModel.recordButtonIsUsed = true
             }
             .sheet(isPresented: $viewModel.travelChoiceModalIsShown) {
                 TravelChoiceInRecordModal(chosenTravel: $viewModel.chosenTravel)
@@ -76,7 +72,6 @@ struct RecordView: View {
     private var travelChoiceView: some View {
         Button {
             viewModel.travelChoiceModalIsShown = true
-            print("viewModel.travelChoiceModalIsShown = true")
         } label: {
             ZStack {
                 Capsule()
@@ -326,7 +321,7 @@ struct RecordView: View {
     
     private var manualRecordButtonView: some View {
         Button {
-            viewModel.needToFill = false
+            viewModel.recordButtonIsUsed = false
             viewModel.manualRecordViewIsShown = true
         } label: {
             ZStack {
@@ -378,11 +373,10 @@ struct RecordView: View {
             } else if oldValue && !newValue {
                 // 녹음 끝
                 viewModel.endRecordTime = CFAbsoluteTimeGetCurrent()
-                print("녹음 끝")
                 isDetectingPress_letButtonBigger = false
                 viewModel.stopSTT()
 //                viewModel.stopRecording()
-                print("time diff: \(viewModel.endRecordTime - viewModel.startRecordTime)")
+//                print("time diff: \(viewModel.endRecordTime - viewModel.startRecordTime)")
                 if Double(viewModel.endRecordTime - viewModel.startRecordTime) < 1.5 {
                     DispatchQueue.main.async {
                         viewModel.alertView_shortIsShown = true
@@ -398,7 +392,6 @@ struct RecordView: View {
                             viewModel.resetInStringProperties()
                         } else {
                             viewModel.manualRecordViewIsShown = true
-                            print("넘어간다 !!!")
                         }
                     }
                 }
@@ -416,7 +409,6 @@ struct RecordView: View {
                 case .second(true, nil):
                     // 녹음 시작 (지점 2: Publishing changes from within view updates 오류 발생 가능)
                     state = true
-                    print("녹음 시작")
                     viewModel.startRecordTime = CFAbsoluteTimeGetCurrent()
 //                    Task {
 //                        await viewModel.startRecording()

--- a/UMM/ViewModel/ManualRecordViewModel.swift
+++ b/UMM/ViewModel/ManualRecordViewModel.swift
@@ -186,6 +186,7 @@ class ManualRecordViewModel: ObservableObject {
     @Published var travelChoiceModalIsShown = false
     @Published var categoryChoiceModalIsShown = false
     @Published var countryChoiceModalIsShown = false
+    @Published var backButtonAlertIsShown = false
     @Published var addingParticipant = false
     @Published var countryIsModified = false
     

--- a/UMM/ViewModel/ManualRecordViewModel.swift
+++ b/UMM/ViewModel/ManualRecordViewModel.swift
@@ -28,7 +28,7 @@ class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
 class ManualRecordViewModel: ObservableObject {
     
     let viewContext = PersistenceController.shared.container.viewContext
-    let handler = ExchangeRateHandler.shared
+    let exchangeHandler = ExchangeRateHandler.shared
     
     // MARK: - 위치 정보
     private var locationManager: CLLocationManager?
@@ -58,7 +58,7 @@ class ManualRecordViewModel: ObservableObject {
             if payAmount == -1 || currency == .unknown {
                 payAmountInWon = -1
             } else {
-                payAmountInWon = payAmount * (handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1) // ^^^
+                payAmountInWon = payAmount * (exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1) // ^^^
             }
         }
     }
@@ -128,8 +128,8 @@ class ManualRecordViewModel: ObservableObject {
     }
     @Published var travelArray: [Travel] = []
     
-    @Published var participantTupleArray: [(String, Bool)] = [("나", true)] // passive
-    @Published var additionalParticipantTupleArray: [(String, Bool)] = []
+    @Published var participantTupleArray: [(name: String, isOn: Bool)] = [("나", true)] // passive
+    @Published var additionalParticipantTupleArray: [(name: String, isOn: Bool)] = []
     
     @Published var payDate: Date = Date()
     var currentDate: Date = Date()
@@ -171,7 +171,7 @@ class ManualRecordViewModel: ObservableObject {
             if payAmount == -1 || currency == .unknown {
                 payAmountInWon = -1
             } else {
-                payAmountInWon = payAmount * (handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1) // ^^^
+                payAmountInWon = payAmount * (exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1) // ^^^
             }
         }
     }
@@ -179,6 +179,20 @@ class ManualRecordViewModel: ObservableObject {
     @Published var visibleNewNameOfParticipant: String = ""
     
     var soundRecordFileName: URL?
+    
+    // MARK: - view state
+    
+    @Published var recordButtonIsUsed = false
+    @Published var travelChoiceModalIsShown = false
+    @Published var categoryChoiceModalIsShown = false
+    @Published var countryChoiceModalIsShown = false
+    @Published var addingParticipant = false
+    @Published var countryIsModified = false
+    
+    // MARK: - timer
+    
+    @Published var autoSaveTimer: Timer?
+    @Published var secondCounter: Int?
     
     init() {
         locationManager = CLLocationManager()
@@ -192,7 +206,7 @@ class ManualRecordViewModel: ObservableObject {
         expense.category = Int64(category.rawValue)
         expense.country = Int64(country.rawValue)
         expense.currency = Int64(currency.rawValue)
-        expense.exchangeRate = handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1 // ^^^
+        expense.exchangeRate = exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency.rawValue))) ?? -1 // ^^^
         expense.info = info
         expense.location = locationExpression
         expense.participantArray = (participantTupleArray + additionalParticipantTupleArray).filter { $0.1 == true }.map { $0.0 }
@@ -218,12 +232,4 @@ class ManualRecordViewModel: ObservableObject {
             print("error saving expense: \(error.localizedDescription)")
         }
     }
-    
-    // MARK: - view state
-    
-    @Published var travelChoiceModalIsShown = false
-    @Published var categoryChoiceModalIsShown = false
-    @Published var countryChoiceModalIsShown = false
-    @Published var addingParticipant = false
-    @Published var countryIsModified = false
 }

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -51,7 +51,7 @@ final class RecordViewModel: ObservableObject {
     
     // view state
     @Published var recordButtonIsFocused = false
-    var needToFill = true
+    var recordButtonIsUsed = true
     
     // STT
     private let audioEngine = AVAudioEngine()


### PR DESCRIPTION
## 👀 이슈
- #142

## 💡 작업 내용
- 포매터를 이용해서 한화로 계산된 작은 괄호 안의 금액에 쉼표를 넣었습니다.
- 지출 장소 수정한 다음부터는 상세주소 Text를 TextField로 대체해서 수정 가능하게 했습니다.
- 결제 인원 버튼을 여러 행에 걸쳐 보여주고 한 행에 세 명씩 배치했습니다.(Hi-fi 수정사항 반영)
- 결제 인원의 플러스 버튼을 없앴습니다.(Hi-fi 수정사항 반영)
- 5초 + 3초 후 자동 저장 타이머와 화면 표현을 구현했습니다. (조작이 있으면 타이머가 invalidate됩니다.)
- 커스텀으로 구현된 네비게이션 바를 기본 코드로 바꿨습니다.
- 뒤로가기 누르면 경고창을 띄웁니다.
- 음성으로 소숫점 뒤 자리 없는 금액을 입력했을 때 ManualRecordView에서 불필요한 ".0"이 붙는 문제를 해결했습니다.

## 📱스크린샷
![Simulator Screen Recording - iPhone 14 - 2023-11-01 at 17 22 00](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/107789649/6980b7d9-eaaa-449f-b713-4c7e29bb2724)

## 🚨 참고 사항
- ManualRecordView에서 아직 구현하지 않은 것은 아래와 같습니다:
	- 지출 일시 수정 기능
	- 녹음된 소리 저장과 재생
	- 한국, 일본, 베트남 화폐는 소숫점 표시 없애기
	- 키보드 관련 문제들(키보드 따라 칸도 올리기, 바깥 터치했을 때 키보드 내리기) 해결하기
- 네비게이션 바는 통일성을 위해 @GYURI-PARK의 뷰와 거의 같은 형식으로 만들었습니다. 스크롤해도 배경이 하얀색으로 유지되도록 아래의 코드를 추가했습니다:
```
.toolbarBackground(.white, for: .navigationBar)
```

## 🤔 고민한 점
- 경고창 등 몇 가지 기능을 넣기 위해 뷰모델에 뷰의 상태를 반영하는 State Bool 변수를 여러 개 추가했습니다.
- 불필요한 ".0"이 붙는 문제는, visiblePayAmount에 초깃값을 줄 때 나머지 부분의 크기가 0.0000001보다 작은지 아닌지로 판단해서 String의 포맷을 다르게 해서 해결했습니다. 코드는 아래와 같습니다:

```
viewModel.payAmount = prevViewModel.payAmount
if viewModel.payAmount == -1 {
    viewModel.visiblePayAmount = ""
} else {
    if abs(viewModel.payAmount - Double(Int(viewModel.payAmount))) < 0.0000001 {
        viewModel.visiblePayAmount = String(format: "%.0f", viewModel.payAmount)
    } else {
        viewModel.visiblePayAmount = String(viewModel.payAmount)
    }
}
```

- 사용자의 조작이 있으면 타이머가 invalidate되게 하기 위해 뷰 안의 모든 상호작용에 onTapGesture로 invalidate() 명령을 추가했습니다.
