### PR TITLE
🎨 [#163] TodayExpenseVIew와 AllExpenseView에 지출 기록이 없는 경우, 표시할 View 추가

### DIFF
--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -22,13 +22,17 @@ struct AllExpenseView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            countryPicker
-            allExpenseSummaryTotal
-            allExpenseSummaryByCurrency
-            allExpenseBarGraph
-            Divider()
-            ScrollView(showsIndicators: false) {
-                drawExpensesByCategory
+            if expenseViewModel.filteredAllExpenses.count == 0 {
+                noDataView
+            } else {
+                countryPicker
+                allExpenseSummaryTotal
+                allExpenseSummaryByCurrency
+                allExpenseBarGraph
+                Divider()
+                ScrollView(showsIndicators: false) {
+                    drawExpensesByCategory
+                }
             }
         }
         .frame(maxWidth: .infinity)
@@ -81,7 +85,7 @@ struct AllExpenseView: View {
                         let amount = (expense.payAmount != -1) ? expense.payAmount : 0
                         return total + amount
                     }
-
+                    
                     Text("\(Currency.getSymbol(of: Int(currency)))\(expenseViewModel.formatSum(from: sum, to: 2))")
                         .font(.caption2)
                         .foregroundStyle(.gray300)
@@ -203,6 +207,16 @@ struct AllExpenseView: View {
             }
         }
     }
+    
+    private var noDataView: some View {
+        VStack(spacing: 0) {
+            Text("아직 지출 기록이 없어요")
+                .font(.subhead3_2)
+                .foregroundStyle(.gray300)
+                .padding(.top, 130)
+            Spacer()
+        }
+    }
 }
 
 struct CurrencyForChart: Identifiable, Hashable {
@@ -250,7 +264,7 @@ struct BarGraph: View {
             ForEach(0..<validDataCount, id: \.self) { index in
                 let item = data[index]
                 let elementWidth = (item.1 / totalSum) * max(0, (deviceWidthWithoutSpacing - totalMinWidth)) + minElementWidth
-
+                
                 BarElement(
                     color: ExpenseInfoCategory(rawValue: Int(item.0))?.color ?? Color.gray,
                     width: (item.1 != 0 ? elementWidth : 0),

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -22,9 +22,8 @@ struct TodayExpenseView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            
             if expenseViewModel.filteredTodayExpenses.count == 0 {
-                noDataVIew
+                noDataView
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
@@ -155,7 +154,7 @@ struct TodayExpenseView: View {
         }
     } // draw
     
-    private var noDataVIew: some View {
+    private var noDataView: some View {
         VStack(spacing: 0) {
             Text("아직 지출 기록이 없어요")
                 .font(.subhead3_2)

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -23,10 +23,14 @@ struct TodayExpenseView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    datePicker
-                    drawExpensesByCountry // 결제 데이터 그리기: 국가 > 결제수단 순서로 분류
+            if expenseViewModel.filteredTodayExpenses.count == 0 {
+                noDataVIew
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        datePicker
+                        drawExpensesByCountry // 결제 데이터 그리기: 국가 > 결제수단 순서로 분류
+                    }
                 }
             }
         }
@@ -39,7 +43,7 @@ struct TodayExpenseView: View {
             expenseViewModel.groupedTodayExpenses = Dictionary(grouping: expenseViewModel.filteredTodayExpenses, by: { $0.country })
         }
     }
-
+    
     private var datePicker: some View {
         CustomDatePicker(expenseViewModel: expenseViewModel, selectedDate: $expenseViewModel.selectedDate, pickerId: pickerId, startDateOfTravel: expenseViewModel.selectedTravel?.startDate ?? Date().addingTimeInterval(-24*60*60))
             .padding(.top, 12)
@@ -49,107 +53,117 @@ struct TodayExpenseView: View {
     // 국가별 + 결제수단별 지출액 표시
     private var drawExpensesByCountry: some View {
         let countryArray = [Int64](Set<Int64>(expenseViewModel.groupedTodayExpenses.keys)).sorted { $0 < $1 }
+        
         return ForEach(countryArray, id: \.self) { country in
-            let paymentMethodArray = Array(Set((expenseViewModel.groupedTodayExpenses[country] ?? []).map { $0.paymentMethod })).sorted { $0 < $1 }
-            let expenseArray = expenseViewModel.groupedTodayExpenses[country] ?? []
-            let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
-            let totalSum = currencies.reduce(0) { total, currency in
-                let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
-                let rate = handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency)))
-                return total + sum * (rate ?? -100)
-            }
-            
-            VStack(alignment: .leading, spacing: 0) {
-                // 국기 + 국가명
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 8) {
-                        Spacer()
-                            .frame(width: 4) // 디자이너 몰래 살짝 움직였다
-                        Image(Country(rawValue: Int(country))?.flagImageString ?? "")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 18, height: 18)
-                            .shadow(color: .gray, radius: 3)
-                        Text(Country(rawValue: Int(country))?.title ?? "-")
-                            .foregroundStyle(.black)
-                            .font(.subhead3_1)
-                    }
-                    
-                    // 결제 수단: 전체: 합계
-                    NavigationLink {
-                        TodayExpenseDetailView(
-                            selectedTravel: expenseViewModel.selectedTravel,
-                            selectedDate: expenseViewModel.selectedDate,
-                            selectedCountry: country,
-                            selectedPaymentMethod: -2,
-                            sumPaymentMethod: totalSum
-                        )
-                    } label: {
-                        Text("\(expenseViewModel.formatSum(from: totalSum, to: 0))원")
-                            .font(.display3)
-                            .foregroundStyle(.black)
-                            .padding(.top, 8)
-                    }
+                let paymentMethodArray = Array(Set((expenseViewModel.groupedTodayExpenses[country] ?? []).map { $0.paymentMethod })).sorted { $0 < $1 }
+                let expenseArray = expenseViewModel.groupedTodayExpenses[country] ?? []
+                let currencies = Array(Set(expenseArray.map { $0.currency })).sorted { $0 < $1 }
+                let totalSum = currencies.reduce(0) { total, currency in
+                    let sum = expenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
+                    let rate = handler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency)))
+                    return total + sum * (rate ?? -100)
                 }
-                .padding(.bottom, 16)
-                
-                // 결제 수단: 개별: 합계
-                ForEach(paymentMethodArray, id: \.self) { paymentMethod in
+                VStack(alignment: .leading, spacing: 0) {
+                    // 국기 + 국가명
                     VStack(alignment: .leading, spacing: 0) {
-                        let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
-                        let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
-
+                        HStack(spacing: 8) {
+                            Spacer()
+                                .frame(width: 4) // 디자이너 몰래 살짝 움직였다
+                            Image(Country(rawValue: Int(country))?.flagImageString ?? "")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 18, height: 18)
+                                .shadow(color: .gray, radius: 3)
+                            Text(Country(rawValue: Int(country))?.title ?? "-")
+                                .foregroundStyle(.black)
+                                .font(.subhead3_1)
+                        }
+                        
+                        // 결제 수단: 전체: 합계
                         NavigationLink {
                             TodayExpenseDetailView(
                                 selectedTravel: expenseViewModel.selectedTravel,
                                 selectedDate: expenseViewModel.selectedDate,
                                 selectedCountry: country,
-                                selectedPaymentMethod: paymentMethod,
-                                sumPaymentMethod: sumPaymentMethod
+                                selectedPaymentMethod: -2,
+                                sumPaymentMethod: totalSum
                             )
                         } label: {
-                            HStack(alignment: .center, spacing: 0) {
-                                VStack(alignment: .leading, spacing: 0) {
-                                    HStack(spacing: 0) {
-                                        Text(PaymentMethod(rawValue: Int(paymentMethod))?.title ?? "-")
-                                            .font(.subhead2_1)
-                                            .foregroundStyle(.gray300)
-                                    }
-                                    // 결제 수단: 개별, 화폐: 개별: 합계
-                                    HStack(spacing: 0) {
-                                        ForEach(currencies.indices, id: \.self) { index in
-                                            let currency = currencies[index]
-                                            let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
-                                            Text((Currency(rawValue: Int(currency))?.officialSymbol ?? "?") + "\(expenseViewModel.formatSum(from: sum, to: 2))")
-                                                .font(.subhead3_1)
-                                                .foregroundStyle(.black)
-                                            
-                                            if index != currencies.count - 1 {
-                                                Divider()
-                                                    .font(.subhead2_1)
-                                                    .foregroundStyle(.gray200)
-                                                    .padding(.horizontal, 5)
+                            Text("\(expenseViewModel.formatSum(from: totalSum, to: 0))원")
+                                .font(.display3)
+                                .foregroundStyle(.black)
+                                .padding(.top, 8)
+                        }
+                    }
+                    .padding(.bottom, 16)
+                    
+                    // 결제 수단: 개별: 합계
+                    ForEach(paymentMethodArray, id: \.self) { paymentMethod in
+                        VStack(alignment: .leading, spacing: 0) {
+                            let filteredExpenseArray = expenseArray.filter { $0.paymentMethod == paymentMethod }
+                            let sumPaymentMethod = filteredExpenseArray.reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
+                            
+                            NavigationLink {
+                                TodayExpenseDetailView(
+                                    selectedTravel: expenseViewModel.selectedTravel,
+                                    selectedDate: expenseViewModel.selectedDate,
+                                    selectedCountry: country,
+                                    selectedPaymentMethod: paymentMethod,
+                                    sumPaymentMethod: sumPaymentMethod
+                                )
+                            } label: {
+                                HStack(alignment: .center, spacing: 0) {
+                                    VStack(alignment: .leading, spacing: 0) {
+                                        HStack(spacing: 0) {
+                                            Text(PaymentMethod(rawValue: Int(paymentMethod))?.title ?? "-")
+                                                .font(.subhead2_1)
+                                                .foregroundStyle(.gray300)
+                                        }
+                                        // 결제 수단: 개별, 화폐: 개별: 합계
+                                        HStack(spacing: 0) {
+                                            ForEach(currencies.indices, id: \.self) { index in
+                                                let currency = currencies[index]
+                                                let sum = filteredExpenseArray.filter({ $0.currency == currency }).reduce(0) { $0 + ($1.payAmount == -1 ? 0 : $1.payAmount) }
+                                                Text((Currency(rawValue: Int(currency))?.officialSymbol ?? "?") + "\(expenseViewModel.formatSum(from: sum, to: 2))")
+                                                    .font(.subhead3_1)
+                                                    .foregroundStyle(.black)
+                                                
+                                                if index != currencies.count - 1 {
+                                                    Divider()
+                                                        .font(.subhead2_1)
+                                                        .foregroundStyle(.gray200)
+                                                        .padding(.horizontal, 5)
+                                                }
                                             }
                                         }
+                                        .padding(.top, 12)
                                     }
-                                    .padding(.top, 12)
+                                    Spacer()
+                                    
                                 }
-                                Spacer()
-                                
+                                .padding(16)
+                                .frame(maxWidth: .infinity)
+                                .background(Color.gray100)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                                .padding(.bottom, 10)
                             }
-                            .padding(16)
-                            .frame(maxWidth: .infinity)
-                            .background(Color.gray100)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .padding(.bottom, 10)
                         }
                     }
                 }
-            }
-            .padding(.top, 20)
-            .padding(.bottom, 10)
+                .padding(.top, 20)
+                .padding(.bottom, 10)
         }
     } // draw
+    
+    private var noDataVIew: some View {
+        VStack(spacing: 0) {
+            Text("아직 지출 기록이 없어요")
+                .font(.subhead3_2)
+                .foregroundStyle(.gray300)
+                .padding(.top, 130)
+            Spacer()
+        }
+    }
 }
 
 struct CurrencyAndSum {


### PR DESCRIPTION
## 👀 이슈
- #163 

## 💡 작업 내용
- TodayExpenseView와 AllExpenseView에 표시할 지출 기록이 없는 경우, 표시할 noDataView를 추가

## 📱스크린샷
![Simulator Screenshot - iPhone 15 - 2023-11-05 at 21 43 35](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/102353544/34ff933a-89ea-4020-8c1d-f6d28aa83561)

## 🚨 참고 사항
- filteredTodayExpenses, filteredAllExpenses를 지출 기록의 판단 기준으로 삼았습니다.
