### PR TITLE
⚡ 🎨 [#173] Expense 관련 뷰에 CountryInfo를 적용합니다. 국기 이미지를 HIFI에 맞춰 수정합니다.

### DIFF
--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -12,9 +12,10 @@ struct AllExpenseView: View {
     @State private var selectedPaymentMethod: Int = -2
     @Binding var selectedTab: Int
     let namespace: Namespace.ID
+    @EnvironmentObject var mainVM: MainViewModel
     let exchangeRatehandler = ExchangeRateHandler.shared
     let currencyInfoModel = CurrencyInfoModel.shared.currencyResult
-    @EnvironmentObject var mainVM: MainViewModel
+    let countryInfoModel = CountryInfoModel.shared.countryResult
     
     init(expenseViewModel: ExpenseViewModel, selectedTab: Binding<Int>, namespace: Namespace.ID) {
         self.expenseViewModel = expenseViewModel
@@ -74,7 +75,7 @@ struct AllExpenseView: View {
                     .foregroundStyle(.gray200)
                     .padding(.leading, 16)
             }
-            .padding(.top, 32)
+            .padding(.top, 16)
         }
     }
     
@@ -124,18 +125,27 @@ struct AllExpenseView: View {
                             expenseViewModel.fetchCountryForAllExpense(country: expenseViewModel.selectedCountry)
                         }
                     }, label: {
-                        Text("\(Country.titleFor(rawValue: Int(country)))")
-                            .padding(.leading, 4)
-                            .font(.caption2)
-                            .frame(width: 61) // 폰트 개수가 다르고, 크기는 고정되어 있어서 상수 값을 주었습니다.
-                            .padding(.vertical, 7)
-                            .background(expenseViewModel.selectedCountry == country ? Color.black: Color.gray100)
-                            .foregroundColor(expenseViewModel.selectedCountry == country ? Color.white: Color.gray300)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        HStack(spacing: 4) {
+                            Image(countryInfoModel[Int(country)]?.flagString ?? "DefaultFlag")
+                                .resizable()
+                                .frame(width: 16, height: 16)
+                                .padding(.leading, 8)
+                            Text("\(countryInfoModel[Int(country)]?.koreanNm ?? "전체")")
+                                .padding(.trailing, 8)
+                                .font(.caption2)
+                                .foregroundColor(expenseViewModel.selectedCountry == country ? Color.white: Color.gray300)
+                        }
+                        .padding(.vertical, 7)
+                        .background(expenseViewModel.selectedCountry == country ? Color.black: Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(expenseViewModel.selectedCountry == country ? Color.clear : Color.gray200, lineWidth: 1)
+                        )
                     })
                 }
             }
-            .padding(.top, 16)
+            .padding(.vertical, 16)
         }
     }
     

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -114,10 +114,26 @@ struct AllExpenseView: View {
     
     private var countryPicker: some View {
         let allExpensesInSelectedTravel = expenseViewModel.filteredAllExpenses
-        let countries = [-2] + Array(Set(allExpensesInSelectedTravel.compactMap { $0.country })).sorted { $0 < $1 } // 중복 제거
+        let countries = Array(Set(allExpensesInSelectedTravel.compactMap { $0.country })).sorted { $0 < $1 } // 중복 제거
         
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 4) {
+                
+                Button(action: {
+                    DispatchQueue.main.async {
+                        expenseViewModel.selectedCountry = Int64(-2)
+                        expenseViewModel.fetchCountryForAllExpense(country: expenseViewModel.selectedCountry)
+                    }
+                }, label: {
+                    Text("전체")
+                        .padding(.vertical, 7)
+                        .frame(width: 61)
+                        .font(.caption2)
+                        .foregroundColor(expenseViewModel.selectedCountry == -2 ? Color.white: Color.gray300)
+                        .background(expenseViewModel.selectedCountry == -2 ? Color.black: Color.gray100)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                })
+                
                 ForEach(countries, id: \.self) { country in
                     Button(action: {
                         DispatchQueue.main.async {
@@ -126,22 +142,19 @@ struct AllExpenseView: View {
                         }
                     }, label: {
                         HStack(spacing: 4) {
-                            Image(countryInfoModel[Int(country)]?.flagString ?? "DefaultFlag")
+                            Image(countryInfoModel[Int(country)]?.flagString ?? "")
                                 .resizable()
                                 .frame(width: 16, height: 16)
+                                .shadow(color: .gray200, radius: 2)
                                 .padding(.leading, 8)
-                            Text("\(countryInfoModel[Int(country)]?.koreanNm ?? "전체")")
+                            Text("\(countryInfoModel[Int(country)]?.koreanNm ?? "")")
                                 .padding(.trailing, 8)
                                 .font(.caption2)
                                 .foregroundColor(expenseViewModel.selectedCountry == country ? Color.white: Color.gray300)
                         }
                         .padding(.vertical, 7)
-                        .background(expenseViewModel.selectedCountry == country ? Color.black: Color.white)
+                        .background(expenseViewModel.selectedCountry == country ? Color.black: Color.gray100)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(expenseViewModel.selectedCountry == country ? Color.clear : Color.gray200, lineWidth: 1)
-                        )
                     })
                 }
             }

--- a/UMM/View/Expense/AllExpenseView.swift
+++ b/UMM/View/Expense/AllExpenseView.swift
@@ -43,7 +43,7 @@ struct AllExpenseView: View {
             print("AllExpenseView | selctedCountry: \(expenseViewModel.selectedCountry)")
             expenseViewModel.fetchExpense()
             expenseViewModel.fetchTravel()
-            expenseViewModel.selectCountry(country: expenseViewModel.selectedCountry)
+            expenseViewModel.fetchCountryForAllExpense(country: expenseViewModel.selectedCountry)
         }
     }
     
@@ -121,7 +121,7 @@ struct AllExpenseView: View {
                     Button(action: {
                         DispatchQueue.main.async {
                             expenseViewModel.selectedCountry = Int64(country)
-                            expenseViewModel.selectCountry(country: expenseViewModel.selectedCountry)
+                            expenseViewModel.fetchCountryForAllExpense(country: expenseViewModel.selectedCountry)
                         }
                     }, label: {
                         Text("\(Country.titleFor(rawValue: Int(country)))")

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -18,9 +18,10 @@ struct TodayExpenseDetailView: View {
     @State private var currencyAndSums: [CurrencyAndSum] = []
     var sumPaymentMethod: Double
     @State private var isPaymentModalPresented = false
+    @EnvironmentObject var mainVM: MainViewModel
     let exchangeRatehandler = ExchangeRateHandler.shared
     let currencyInfoModel = CurrencyInfoModel.shared.currencyResult
-    @EnvironmentObject var mainVM: MainViewModel
+    let countryInfoModel = CountryInfoModel.shared.countryResult
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -99,12 +100,12 @@ struct TodayExpenseDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             // 나라 이름
             HStack(alignment: .center, spacing: 8) {
-                Image(Country(rawValue: Int(selectedCountry))?.flagImageString ?? "")
+                Image(countryInfoModel[Int(selectedCountry)]?.flagString ?? "")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 24, height: 24)
                     .shadow(color: .gray, radius: 3)
-                Text("\(Country.titleFor(rawValue: Int(selectedCountry)))")
+                Text("\(countryInfoModel[Int(selectedCountry)]?.koreanNm ?? "")")
                     .font(.display1)
                     .padding(.leading, 8)
             }

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -107,7 +107,6 @@ struct TodayExpenseDetailView: View {
                     .shadow(color: .gray200, radius: 2)
                 Text("\(countryInfoModel[Int(selectedCountry)]?.koreanNm ?? "")")
                     .font(.display1)
-                    .padding(.leading, 8)
             }
             
             // 총 합계

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -104,7 +104,7 @@ struct TodayExpenseDetailView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 24, height: 24)
-                    .shadow(color: .gray, radius: 3)
+                    .shadow(color: .gray200, radius: 2)
                 Text("\(countryInfoModel[Int(selectedCountry)]?.koreanNm ?? "")")
                     .font(.display1)
                     .padding(.leading, 8)

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -155,7 +155,7 @@ struct TodayExpenseView: View {
                             }
                             Spacer()
                             Image(systemName: "chevron.right")
-                                .font(.system(size: 24))
+                                .font(.system(size: 16))
                                 .foregroundStyle(.gray200)
                                 .padding(.trailing, 16)
                         }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -73,12 +73,12 @@ struct TodayExpenseView: View {
                     HStack(spacing: 8) {
                         Spacer()
                             .frame(width: 4) // 디자이너 몰래 살짝 움직였다
-                        Image(countryInfoModel[Int(country)]?.flagString ?? "-")
+                        Image(countryInfoModel[Int(country)]?.flagString ?? "")
                             .resizable()
                             .scaledToFit()
                             .frame(width: 18, height: 18)
                             .shadow(color: .gray, radius: 3)
-                        Text(countryInfoModel[Int(country)]?.koreanNm ?? "-")
+                        Text(countryInfoModel[Int(country)]?.koreanNm ?? "")
                             .foregroundStyle(.black)
                             .font(.subhead3_1)
                     }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -71,13 +71,11 @@ struct TodayExpenseView: View {
                 // 국기 + 국가명
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 8) {
-                        Spacer()
-                            .frame(width: 4) // 디자이너 몰래 살짝 움직였다
                         Image(countryInfoModel[Int(country)]?.flagString ?? "")
                             .resizable()
-                            .scaledToFit()
                             .frame(width: 18, height: 18)
-                            .shadow(color: .gray, radius: 3)
+                            .shadow(color: Color.gray200, radius: 2)
+                            .padding(.leading, 2)
                         Text(countryInfoModel[Int(country)]?.koreanNm ?? "")
                             .foregroundStyle(.black)
                             .font(.subhead3_1)

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -12,9 +12,10 @@ struct TodayExpenseView: View {
     @Binding var selectedTab: Int
     let namespace: Namespace.ID
     var pickerId: String { "picker" }
+    @EnvironmentObject var mainVM: MainViewModel
     let exchangeRateHandler = ExchangeRateHandler.shared
     let currencyInfoModel = CurrencyInfoModel.shared.currencyResult
-    @EnvironmentObject var mainVM: MainViewModel
+    let countryInfoModel = CountryInfoModel.shared.countryResult
     
     init(expenseViewModel: ExpenseViewModel, selectedTab: Binding<Int>, namespace: Namespace.ID) {
         self.expenseViewModel = expenseViewModel
@@ -72,12 +73,12 @@ struct TodayExpenseView: View {
                     HStack(spacing: 8) {
                         Spacer()
                             .frame(width: 4) // 디자이너 몰래 살짝 움직였다
-                        Image(Country(rawValue: Int(country))?.flagImageString ?? "")
+                        Image(countryInfoModel[Int(country)]?.flagString ?? "-")
                             .resizable()
                             .scaledToFit()
                             .frame(width: 18, height: 18)
                             .shadow(color: .gray, radius: 3)
-                        Text(Country(rawValue: Int(country))?.title ?? "-")
+                        Text(countryInfoModel[Int(country)]?.koreanNm ?? "-")
                             .foregroundStyle(.black)
                             .font(.subhead3_1)
                     }

--- a/UMM/View/Expense/TodayExpenseView.swift
+++ b/UMM/View/Expense/TodayExpenseView.swift
@@ -91,10 +91,16 @@ struct TodayExpenseView: View {
                             sumPaymentMethod: totalSum
                         )
                     } label: {
-                        Text("\(expenseViewModel.formatSum(from: totalSum, to: 0))원")
-                            .font(.display3)
-                            .foregroundStyle(.black)
-                            .padding(.top, 8)
+                        HStack(spacing: 0) {
+                            Text("\(expenseViewModel.formatSum(from: totalSum, to: 0))원")
+                                .font(.display3)
+                                .foregroundStyle(.black)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 24))
+                                .foregroundStyle(.gray200)
+                                .padding(.leading, 16)
+                        }
+                        .padding(.top, 8)
                     }
                 }
                 .padding(.bottom, 16)
@@ -148,6 +154,10 @@ struct TodayExpenseView: View {
                                 .padding(.top, 12)
                             }
                             Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 24))
+                                .foregroundStyle(.gray200)
+                                .padding(.trailing, 16)
                         }
                         .padding(16)
                         .frame(maxWidth: .infinity)

--- a/UMM/ViewModel/ExpenseViewModel.swift
+++ b/UMM/ViewModel/ExpenseViewModel.swift
@@ -29,7 +29,7 @@ class ExpenseViewModel: ObservableObject {
     @Published var selectedCountry: Int64 = -2 {
         didSet {
             print("Country changed to: \(selectedCountry)")
-            self.selectCountry(country: selectedCountry)
+            self.fetchCountryForAllExpense(country: selectedCountry)
         }
     }
     @Published var selectedCategory: Int64 = 0
@@ -72,37 +72,6 @@ class ExpenseViewModel: ObservableObject {
             fetchExpense()
         } catch let error {
             print("Error while saveExpense: \(error.localizedDescription)")
-        }
-    }
-    
-    func addExpense(travel: Travel) {
-        let infos = ["여행", "쇼핑", "관광"]
-        let participantArray = [["John", "Alice"], ["Bob"], ["Charlie"]]
-        let payAmounts = [50.0, 1000.25, 80.0]
-        let locations = ["서울", "도쿄", "파리", "상파울루", "바그다드", "짐바브웨"]
-        let exchangeRates = [1.0, 0.009, 1.1]
-
-        let tempExpense = Expense(context: viewContext)
-        tempExpense.currency = Int64(Int.random(in: -1...6))
-        tempExpense.exchangeRate = exchangeRates.randomElement() ?? 0.5
-        tempExpense.info = infos.randomElement()
-        tempExpense.location = locations.randomElement()
-        tempExpense.participantArray = participantArray.randomElement()
-        tempExpense.paymentMethod = Int64(Int.random(in: -1...1))
-        tempExpense.payAmount = Double(payAmounts.randomElement() ?? 300.0)
-        tempExpense.payDate = Date()
-        tempExpense.category = Int64(Int.random(in: -1...5))
-        tempExpense.country = Int64(Int.random(in: -1...5))
-        
-        // 현재 선택된 여행에 추가할 수 있도록
-        self.fetchTravel()
-        if let targetTravel = self.savedTravels.first(where: { $0.id == travel.id}) {
-            targetTravel.addToExpenseArray(tempExpense)
-            targetTravel.lastUpdate = Date()
-            print("targetTravel.lastUpdate: \(String(describing: targetTravel.lastUpdate))")
-            saveExpense()
-        } else {
-            print("Error while addExpense")
         }
     }
 
@@ -247,7 +216,7 @@ class ExpenseViewModel: ObservableObject {
         return indexedSumArray
     }
     
-    func selectCountry(country: Int64) {
+    func fetchCountryForAllExpense(country: Int64) {
         filteredAllExpenses = getFilteredAllExpenses()
         filteredAllExpensesByCountry = filterExpensesByCountry(expenses: filteredAllExpenses, country: country)
         groupedAllExpenses = Dictionary(grouping: filteredAllExpensesByCountry, by: { $0.category })


### PR DESCRIPTION
## 👀 이슈
- #173 

## 💡 작업 내용
- Expense 관련 뷰에 CountryInfo를 적용
- Expense 관련 뷰에 국기 이미지의 GUI를 HIFI에 맞게 수정
- TodayExpenseView에 chevron을 디자이너 모르게 수정 (지금은 아는 상태)

## 📱스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-11-06 at 16 24 17](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/102353544/7551ce56-9b15-427a-8da8-af7ff5ea5e10)

## 🚨 참고 사항
~~TodayExpenseView의 chevron은 수정할 예정입니다.~~ 완료
