### PR TITLE
🎨[#196] ManualRecordView 소소한 수정을 합니다.

### DIFF
--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -159,6 +159,7 @@ struct ManualRecordView: View {
                                     mainVM.selectedTravel = mainVM.chosenTravelInManualRecord
                                 }
                                 mainVM.alertView_savedIsShown = true
+                                viewModel.deleteUselessAudioFiles()
                                 self.dismiss()
                                 timer.invalidate()
                             } else {
@@ -845,6 +846,7 @@ struct ManualRecordView: View {
                     mainVM.selectedTravel = defaultTravel
                 }
                 mainVM.alertView_savedIsShown = true
+                viewModel.deleteUselessAudioFiles()
                 dismiss()
                 
             }

--- a/UMM/View/Record/ManualRecordView.swift
+++ b/UMM/View/Record/ManualRecordView.swift
@@ -44,6 +44,8 @@ struct ManualRecordView: View {
                 Spacer()
                     .frame(height: 16)
                 saveButtonView
+                Spacer()
+                    .frame(height: 45)
             }
             .ignoresSafeArea()
         }

--- a/UMM/View/Record/RecordView.swift
+++ b/UMM/View/Record/RecordView.swift
@@ -498,6 +498,7 @@ struct RecordView: View {
                         isDetectingPress_showOnButton = true
                         viewModel.alertView_emptyIsShown = false
                         viewModel.alertView_shortIsShown = false
+//                        mainVM.alertView_savedIsShown = false // 이걸 추가하면 STT가 안 됨
                         viewModel.recordButtonIsFocused = true
                     }
                 default:

--- a/UMM/ViewModel/ManualRecordViewModel.swift
+++ b/UMM/ViewModel/ManualRecordViewModel.swift
@@ -306,6 +306,23 @@ final class ManualRecordViewModel: NSObject, ObservableObject {
     func stopPlayingAudio() {
         audioPlayer?.stop()
     }
+    
+    func deleteUselessAudioFiles() {
+        let soundRecordPath: URL? = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        
+        // VOICE로 시작하는 파일 삭제
+        if let soundRecordPath {
+            do {
+                let fileManager = FileManager.default
+                let filesInDirectory = try fileManager.contentsOfDirectory(at: soundRecordPath, includingPropertiesForKeys: nil)
+                for fileURL in filesInDirectory where fileURL.lastPathComponent.hasPrefix("VOICE") {
+                    try fileManager.removeItem(at: fileURL)
+                }
+            } catch {
+                print("error deleting sound files: \(error.localizedDescription)")
+            }
+        }
+    }
 }
 
 extension ManualRecordViewModel: AVAudioPlayerDelegate {

--- a/UMM/ViewModel/ManualRecordViewModel.swift
+++ b/UMM/ViewModel/ManualRecordViewModel.swift
@@ -246,7 +246,8 @@ final class ManualRecordViewModel: NSObject, ObservableObject {
         expense.category = Int64(category.rawValue)
         expense.country = Int64(country)
         expense.currency = Int64(currency)
-        expense.exchangeRate = exchangeHandler.getExchangeRateFromKRW(currencyCode: Currency.getCurrencyCodeName(of: Int(currency))) ?? -1
+        let code = CurrencyInfoModel.shared.currencyResult[currency]?.isoCodeNm ?? "Unknown"
+        expense.exchangeRate = exchangeHandler.getExchangeRateFromKRW(currencyCode: code) ?? -1
         expense.info = info
         expense.location = locationExpression
         expense.participantArray = participantTupleArray.filter { $0.1 == true }.map { $0.0 }

--- a/UMM/ViewModel/RecordViewModel.swift
+++ b/UMM/ViewModel/RecordViewModel.swift
@@ -657,7 +657,6 @@ final class RecordViewModel: ObservableObject {
                 let filesInDirectory = try fileManager.contentsOfDirectory(at: soundRecordPath, includingPropertiesForKeys: nil)
                 for fileURL in filesInDirectory where fileURL.lastPathComponent.hasPrefix("VOICE") {
                     try fileManager.removeItem(at: fileURL)
-                    print("Deleted file: \(fileURL.lastPathComponent)")
                 }
             } catch {
                 print("error deleting sound files: \(error.localizedDescription)")


### PR DESCRIPTION
## 👀 이슈
- #196

## 💡 작업 내용
- ManualRecordView 저장 버튼이 갑자기 너무 아래로 옮겨져서 위치 조정
- ManualRecordViewModel의 save() 메서드 안에 Currency 이뉴머레이션을 아직 사용하는 코드 있는데 그것 수정
- ManualRecordView에서 지출 저장하고서 불필요한 오디오 파일 삭제하기

## 📱스크린샷
-

## 🚨 참고 사항
- 녹음 버튼 누를 때 '저장되었습니다' 안내를 없애고 싶었는데 STT가 멈춰버리는 문제가 있어서 없애지 못했습니다.