### PR TITLE
⚡️[#178][#209][#211]  화폐단위 적용, 여행 삭제 기능 구현, DateGapHandler 적용

### DIFF
--- a/UMM/Model/Persistence.swift
+++ b/UMM/Model/Persistence.swift
@@ -41,4 +41,25 @@ struct PersistenceController {
         container.viewContext.undoManager = nil
         container.viewContext.shouldDeleteInaccessibleFaults = true
       }
+    
+    func deleteItems(object: Travel?) {
+
+        var travelToBeDeleted: Travel?
+        do {
+            travelToBeDeleted = try self.container.viewContext.fetch(Travel.fetchRequest()).filter { travel in
+                if let object {
+                    return object.id == travel.id
+                }
+                return false
+            }.first
+        } catch {
+            print("error fetching travel: \(error.localizedDescription)")
+        }
+        
+        if travelToBeDeleted != nil {
+            self.container.viewContext.delete(travelToBeDeleted!)
+        }
+
+        try? self.container.viewContext.save()
+    }
 }

--- a/UMM/View/Record/InterimOncomingView.swift
+++ b/UMM/View/Record/InterimOncomingView.swift
@@ -19,12 +19,13 @@ struct InterimOncomingView: View {
     @State var chosenTravel: Travel?
     @State var flagImageDict: [UUID: [String]] = [:]
     @State var defaultImg: [UUID: [String]] = [:]
-    
     @State var savedExpenses: [Expense]? = []
     
     @ObservedObject var viewModel: InterimRecordViewModel
     
     @Binding var isSelectedTravel: Bool
+    
+    let dateGapHandler = DateGapHandler.shared
     
     var body: some View {
         ZStack {
@@ -119,14 +120,14 @@ struct InterimOncomingView: View {
                                             // Doris : 날짜 표시
                                             VStack(alignment: .leading, spacing: 0) {
                                                 HStack {
-                                                    Text(onComingTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     
                                                     Text("~")
                                                 }
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(onComingTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                             }
@@ -273,14 +274,14 @@ struct InterimOncomingView: View {
                                                             // Doris : 날짜 표시
                                                             VStack(alignment: .leading, spacing: 0) {
                                                                 HStack {
-                                                                    Text(onComingTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     
                                                                     Text("~")
                                                                 }
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(onComingTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     .font(.caption2)
                                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                             }

--- a/UMM/View/Record/InterimPastView.swift
+++ b/UMM/View/Record/InterimPastView.swift
@@ -21,10 +21,11 @@ struct InterimPastView: View {
     @State var chosenTravel: Travel?
     @State var flagImageDict: [UUID: [String]] = [:]
     @State var defaultImg: [UUID: [String]] = [:]
-    
     @State var savedExpenses: [Expense]? = []
     
     @Binding var isSelectedTravel: Bool
+    
+    let dateGapHandler = DateGapHandler.shared
     
     var body: some View {
         ZStack {
@@ -119,14 +120,14 @@ struct InterimPastView: View {
                                             // Doris : 날짜 표시
                                             VStack(alignment: .leading, spacing: 0) {
                                                 HStack {
-                                                    Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     
                                                     Text("~")
                                                 }
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                             }
@@ -275,14 +276,14 @@ struct InterimPastView: View {
                                                             // Doris : 날짜 표시
                                                             VStack(alignment: .leading, spacing: 0) {
                                                                 HStack {
-                                                                    Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     
                                                                     Text("~")
                                                                 }
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     .font(.caption2)
                                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                             }

--- a/UMM/View/Record/InterimProceedingView.swift
+++ b/UMM/View/Record/InterimProceedingView.swift
@@ -25,6 +25,8 @@ struct InterimProceedingView: View {
     
     @Binding var isSelectedTravel: Bool
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         ZStack {
             if proceedingCnt == 0 {
@@ -118,14 +120,14 @@ struct InterimProceedingView: View {
                                             // Doris : 날짜 표시
                                             VStack(alignment: .leading, spacing: 0) {
                                                 HStack {
-                                                    Text(nowTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     
                                                     Text("~")
                                                 }
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(nowTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                             }
@@ -275,14 +277,14 @@ struct InterimProceedingView: View {
                                                               // Doris : 날짜 표시
                                                               VStack(alignment: .leading, spacing: 0) {
                                                                   HStack {
-                                                                      Text(nowTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                      Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                       
                                                                       Text("~")
                                                                   }
                                                                   .font(.caption2)
                                                                   .foregroundStyle(Color.white.opacity(0.75))
                                                                   
-                                                                  Text(nowTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                  Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                       .font(.caption2)
                                                                       .foregroundStyle(Color.white.opacity(0.75))
                                                               }

--- a/UMM/View/Record/InterimRecordView.swift
+++ b/UMM/View/Record/InterimRecordView.swift
@@ -23,6 +23,8 @@ struct InterimRecordView: View {
     
     @ObservedObject private var viewModel = InterimRecordViewModel()
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         VStack(spacing: 0) {
             titleHeader
@@ -122,11 +124,11 @@ struct InterimRecordView: View {
                             }
                             
                             Group {
-                                Text(dateFormatterWithDay.string(from: defaultExpense?[index].payDate ?? Date()))
+                                Text(dateFormatterWithDay.string(from: dateGapHandler.convertBeforeShowing(date: defaultExpense?[index].payDate ?? Date())))
                                 +
                                 Text(" ")
                                 +
-                                Text(dateFormatterWithHourMiniute(date: defaultExpense?[index].payDate ?? Date()))
+                                Text(dateFormatterWithHourMiniute(date: dateGapHandler.convertBeforeShowing(date: defaultExpense?[index].payDate ?? Date())))
                             }
                             .font(.caption2)
                             .foregroundStyle(Color.gray400)

--- a/UMM/View/Record/InterimRecordView.swift
+++ b/UMM/View/Record/InterimRecordView.swift
@@ -95,8 +95,11 @@ struct InterimRecordView: View {
                                 Group {
                                     Text("\(viewModel.formatAmount(amount: defaultExpense?[index].payAmount))")
                                     +
-                                    Text(" 원") // Doris
+                                    Text(" ")
+                                    +
+                                    Text((CountryInfoModel.shared.countryResult[Int(((defaultExpense?[index].country) ?? -1))]?.relatedCurrencyArray[0]) ?? "-")
                                 }
+
                                 .font(.display2)
                                 .foregroundStyle(Color.black)
                                 

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -23,6 +23,8 @@ struct AddMemberView: View {
     @State private var isBackButton = false
     @State var isDisappear = false
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         VStack {
             
@@ -54,8 +56,8 @@ struct AddMemberView: View {
                     
                     viewModel.participantArr = ["me"] + participantArr
                 }
-                viewModel.startDate = startDate
-                viewModel.endDate = endDate
+                viewModel.startDate = dateGapHandler.convertBeforeSaving(date: startDate ?? Date())
+                viewModel.endDate = dateGapHandler.convertBeforeSaving(date: endDate ?? Date())
                 
                 // 여행 이름
                 if let arr = viewModel.participantArr {

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -22,6 +22,8 @@ struct PreviousTravelView: View {
     @State var defaultImg: [UUID: [String]] = [:]
     @State private var countryName: [UUID: [String]] = [:]
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         
         ZStack {
@@ -91,7 +93,7 @@ struct PreviousTravelView: View {
                                                 VStack(alignment: .leading, spacing: 0) {
                                                     
                                                     HStack {
-                                                        Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                         
                                                         Text("~")
                                                         
@@ -100,7 +102,7 @@ struct PreviousTravelView: View {
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                     
-                                                    Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                         .font(.caption2)
                                                         .foregroundStyle(Color.white.opacity(0.75))
                                                 }
@@ -225,7 +227,7 @@ struct PreviousTravelView: View {
                                                             VStack(alignment: .leading, spacing: 0) {
                                                                 
                                                                 HStack {
-                                                                    Text(previousTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     
                                                                     Text("~")
                                                                     
@@ -234,7 +236,7 @@ struct PreviousTravelView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(previousTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     .font(.caption2)
                                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                             }

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -98,11 +98,10 @@ struct TravelDetailView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack {
                         Button {
-                            // deleteItems에서 강제 언래핑을 사용하고 있으므로 혹시나모를 상황을 대비해 selectedTravel이 nil일 경우 임의의 Travel을 생성..?
-//                            PersistenceController().deleteItems(viewContext, self.selectedTravel?.first)
                             isWarningOn = true
                         } label: {
                             Image(systemName: "trash")
+                                .foregroundStyle(Color.gray200)
                                 .frame(width: 20, height: 20)
                         }
                         
@@ -114,6 +113,14 @@ struct TravelDetailView: View {
                         }
                     }
                 }
+            }
+            .alert("Alert Title", isPresented: $isWarningOn) {
+                Button("Ok") {
+                    PersistenceController().deleteItems(object: self.selectedTravel?.first)
+                    NavigationUtil.popToRootView()
+                }
+            } message: {
+                Text("This is alert dialog sample")
             }
         }
         .toolbar(.hidden, for: .tabBar)

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -28,6 +28,8 @@ struct TravelDetailView: View {
     
     @State var isWarningOn = false
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -198,7 +200,7 @@ struct TravelDetailView: View {
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
                         .padding(.bottom, 8)
-                    Text(startDate, formatter: TravelDetailViewModel.dateFormatter)
+                    Text(dateGapHandler.convertBeforeShowing(date: startDate), formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
                 }
@@ -217,7 +219,7 @@ struct TravelDetailView: View {
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
                         .padding(.bottom, 8)
-                    Text(endDate, formatter: TravelDetailViewModel.dateFormatter)
+                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: TravelDetailViewModel.dateFormatter)
                         .font(.body4)
                         .foregroundStyle(Color.white)
                 }

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -45,7 +45,7 @@ struct TravelListView: View {
                 TravelTabView()
             }
             .onAppear {
-                DispatchQueue.main.async {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     viewModel.fetchTravel()
                     viewModel.fetchExpense()
                     viewModel.fetchDefaultTravel()

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -349,7 +349,9 @@ struct TravelListView: View {
                                 +
                                 Text("\(viewModel.formatAmount(amount: defaultExpense?.first?.payAmount))")
                                 +
-                                Text("원") // Doris
+                                Text(" ")
+                                +
+                                Text(CountryInfoModel.shared.countryResult[Int(defaultExpense?.first?.currency ?? -1)]?.relatedCurrencyArray[0] ?? "-")
                             }
                                 .font(.caption2)
                                 .foregroundColor(Color.gray300)

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -243,6 +243,9 @@ struct TravelListView: View {
                                     }
                                     .onAppear {
                                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                            viewModel.updateTravel()
+                                            viewModel.saveTravel()
+                                            
                                             self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
                                             if let savedExpenses = savedExpenses {
                                                 let countryValues: [Int64] = savedExpenses.map { expense in

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -27,6 +27,7 @@ struct TravelListView: View {
     @State private var flagImageName: [String] = []
     @State private var defaultImageName: [String] = []
     @State private var countryName: [String] = []
+//    @State private var tempTravelCurrency: String
     
     let handler = ExchangeRateHandler.shared
     
@@ -241,7 +242,6 @@ struct TravelListView: View {
                                         
                                     }
                                     .onAppear {
-                                        print("indexxxxx", index)
                                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                                             self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
                                             if let savedExpenses = savedExpenses {

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -27,8 +27,8 @@ struct TravelListView: View {
     @State private var flagImageName: [String] = []
     @State private var defaultImageName: [String] = []
     @State private var countryName: [String] = []
-//    @State private var tempTravelCurrency: String
-    
+
+    let dateGapHandler = DateGapHandler.shared
     let handler = ExchangeRateHandler.shared
     
     var body: some View {
@@ -196,7 +196,7 @@ struct TravelListView: View {
                                             Group {
                                                 Text("Day ")
                                                 +
-                                                Text("\(viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()))")
+                                                Text("\(viewModel.differenceBetweenToday(today: dateGapHandler.convertBeforeShowing(date: Date()), startDate: dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date())))")
                                             }
                                             .font(.caption1)
                                             .foregroundStyle(Color.white)
@@ -210,9 +210,9 @@ struct TravelListView: View {
                                             
                                             HStack {
                                                 Group {
-                                                    Text(nowTravel?[index].startDate ?? Date(), formatter: TravelListViewModel.dateFormatter) +
+                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: TravelListViewModel.dateFormatter) +
                                                     Text(" ~ ") +
-                                                    Text(nowTravel?[index].endDate ?? Date(), formatter: TravelListViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: TravelListViewModel.dateFormatter)
                                                 }
                                                 .font(.subhead2_2)
                                                 .foregroundStyle(Color.white.opacity(0.75))

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -23,6 +23,8 @@ struct UpcomingTravelView: View {
     @State var defaultImg: [UUID: [String]] = [:]
     @State private var countryName: [UUID: [String]] = [:]
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         
         ZStack {
@@ -92,7 +94,7 @@ struct UpcomingTravelView: View {
                                                 VStack(alignment: .leading, spacing: 0) {
                                                     
                                                     HStack {
-                                                        Text(upcomingTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                         
                                                         Text("~")
                                                         
@@ -101,7 +103,7 @@ struct UpcomingTravelView: View {
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                     
-                                                    Text(upcomingTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                    Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                         .font(.caption2)
                                                         .foregroundStyle(Color.white.opacity(0.75))
                                                 }
@@ -226,7 +228,7 @@ struct UpcomingTravelView: View {
                                                             VStack(alignment: .leading, spacing: 0) {
                                                                 
                                                                 HStack {
-                                                                    Text(upcomingTravel?[index].startDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     
                                                                     Text("~")
                                                                     
@@ -235,7 +237,7 @@ struct UpcomingTravelView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(upcomingTravel?[index].endDate ?? Date(), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                     .font(.caption2)
                                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                             }

--- a/UMM/ViewModel/CompleteAddTravelViewModel.swift
+++ b/UMM/ViewModel/CompleteAddTravelViewModel.swift
@@ -12,7 +12,6 @@ class CompleteAddTravelViewModel: ObservableObject {
     let viewContext = PersistenceController.shared.container.viewContext
     
     @Published var savedTravel: [Travel] = []
-//    @Published var selectedTravel: Travel?
     @Published var travelID = UUID()
     @Published var startDate: Date?
     @Published var endDate: Date?

--- a/UMM/ViewModel/TravelListViewModel.swift
+++ b/UMM/ViewModel/TravelListViewModel.swift
@@ -30,6 +30,20 @@ class TravelListViewModel: ObservableObject {
         }
     }
     
+    func updateTravel() {
+        let travel = Travel(context: viewContext)
+        travel.name = nowTravel.first?.name
+    }
+    
+    func saveTravel() {
+        do {
+            try viewContext.save()
+            print("save travel")
+        } catch let error {
+            print("Error while SaveTravel: \(error.localizedDescription)")
+        }
+    }
+    
     func fetchDefaultTravel() {
         let request = NSFetchRequest<Travel>(entityName: "Travel")
         do {


### PR DESCRIPTION
## 👀 이슈
- #178 
- #193 
- #209 
- #211 


## 💡 작업 내용
- Travel 관련 뷰에 화폐단위 적용 
- 여행 삭제 기능 구현
- 날짜를 보여주고 저장하는 곳에 DateGapHandler 적용 @oliver-or-not 확인 요망
- 여행 제목을 변경할 경우 CoreDate에 Name만 Update


## 📱스크린샷

![Simulator Screen Recording - iPhone 15 - 2023-11-08 at 05 10 19](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/03384f35-feff-45e6-b2bf-0ae51bca0f64)

## 🚨 참고 사항
CompleteAddTravelView에서 이름 변경 

```swift
.onDisappear {
            selectedTravel?.first?.name = travelNM
            mainVM.selectedTravel = self.selectedTravel?.first
        }
```
</br>

TravelListView가 onAppear시 CoreDate 업데이트 및 저장
```swift
 viewModel.updateTravel()
 viewModel.saveTravel()

func updateTravel() {
        let travel = Travel(context: viewContext)
        travel.name = nowTravel.first?.name
    }
    
func saveTravel() {
        do {
            try viewContext.save()
            print("save travel")
        } catch let error {
            print("Error while SaveTravel: \(error.localizedDescription)")
        }
    }
                                            
```

## (Optional) 🤔 고민한 점

