### PR TITLE
⚡ 🎨 [#218] DetailView와 ManualRecordInExpenseView를 연결하고 기능을 구현했습니다.

### DIFF
--- a/UMM/View/Expense/AllExpenseDetailView.swift
+++ b/UMM/View/Expense/AllExpenseDetailView.swift
@@ -167,57 +167,75 @@ struct AllExpenseDetailView: View {
                     .padding(.bottom, 16)
                     
                     ForEach(expensesForDate, id: \.id) { expense in
-                        HStack(alignment: .center, spacing: 0) {
-                            
-                            Image(ExpenseInfoCategory(rawValue: Int(expense.category))?.modalImageString ?? "nil")
-                                .font(.system(size: 36))
-                            
-                            VStack(alignment: .leading, spacing: 0) {
-                                Text("\(expense.info ?? "info : unknown")")
-                                    .font(.subhead2_1)
+                        
+                        NavigationLink {
+                            ManualRecordInExpenseView(
+                                given_wantToActivateAutoSaveTimer: false,
+                                given_payAmount: expense.payAmount,
+                                given_currency: Int(expense.currency),
+                                given_info: expense.info,
+                                given_infoCategory: ExpenseInfoCategory(rawValue: Int(expense.category)) ?? .unknown,
+                                given_paymentMethod: PaymentMethod(rawValue: Int(expense.paymentMethod)) ?? .unknown,
+                                given_soundRecordData: expense.voiceRecordFile,
+                                given_expense: expense,
+                                given_payDate: expense.payDate,
+                                given_country: Int(expense.country),
+                                given_location: expense.location,
+                                given_id: expense.id
+                            )
+                                .environmentObject(mainVM) // ^^^
+                        } label : {
+                            HStack(alignment: .center, spacing: 0) {
+                                Image(ExpenseInfoCategory(rawValue: Int(expense.category))?.modalImageString ?? "nil")
+                                    .font(.system(size: 36))
                                 
-                                HStack(alignment: .center, spacing: 0) {
-                                    // 소비 기록을 한 시각을 보여주는 부분
-                                    // 저장된 expense.payDate를 현지 시각으로 변환해서 보여준다.
-                                    if let payDate = expense.payDate {
-                                        Text("\(dateFormatterWithHourMiniute(date: dateGapHandler.convertBeforeShowing(date: payDate)))")
-                                            .font(.caption2)
-                                            .foregroundStyle(.gray300)
-                                    } else {
-                                        Text("-")
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Text("\(expense.info ?? "info : unknown")")
+                                        .font(.subhead2_1)
+                                    
+                                    HStack(alignment: .center, spacing: 0) {
+                                        // 소비 기록을 한 시각을 보여주는 부분
+                                        // 저장된 expense.payDate를 현지 시각으로 변환해서 보여준다.
+                                        if let payDate = expense.payDate {
+                                            Text("\(dateFormatterWithHourMiniute(date: dateGapHandler.convertBeforeShowing(date: payDate)))")
+                                                .font(.caption2)
+                                                .foregroundStyle(.gray300)
+                                        } else {
+                                            Text("-")
+                                                .font(.caption2)
+                                                .foregroundStyle(.gray300)
+                                        }
+                                        Divider()
+                                            .padding(.horizontal, 3 )
+                                        
+                                        Text("\(PaymentMethod.titleFor(rawValue: Int(expense.paymentMethod)))")
                                             .font(.caption2)
                                             .foregroundStyle(.gray300)
                                     }
-                                    Divider()
-                                        .padding(.horizontal, 3 )
-                                    
-                                    Text("\(PaymentMethod.titleFor(rawValue: Int(expense.paymentMethod)))")
+                                    .padding(.top, 4)
+                                }
+                                .padding(.leading, 10)
+                                
+                                Spacer()
+                                
+                                VStack(alignment: .trailing, spacing: 0) {
+                                    HStack(alignment: .center, spacing: 0) {
+                                        Text("\(Currency.getSymbol(of: Int(expense.currency)))")
+                                            .font(.subhead2_1)
+                                        
+                                        Text("\(expenseViewModel.formatSum(from: expense.payAmount == -1 ? Double.nan : expense.payAmount, to: 2))")
+                                            .font(.subhead2_1)
+                                            .padding(.leading, 3 )
+                                    }
+                                    let currencyCodeName = Currency.getCurrencyCodeName(of: Int(expense.currency))
+                                    let exchangeRate = exchangeRatehandler.getExchangeRateFromKRW(currencyCode: currencyCodeName) ?? -100
+                                    let payAmount = expense.payAmount == -1 ? Double.nan : expense.payAmount * exchangeRate
+                                    let formattedPayAmount = expenseViewModel.formatSum(from: payAmount, to: 0)
+                                    Text("(\(formattedPayAmount)원)")
                                         .font(.caption2)
-                                        .foregroundStyle(.gray300)
+                                        .foregroundStyle(.gray200)
+                                        .padding(.top, 4 )
                                 }
-                                .padding(.top, 4)
-                            }
-                            .padding(.leading, 10)
-                            
-                            Spacer()
-                            
-                            VStack(alignment: .trailing, spacing: 0) {
-                                HStack(alignment: .center, spacing: 0) {
-                                    Text("\(Currency.getSymbol(of: Int(expense.currency)))")
-                                        .font(.subhead2_1)
-                                    
-                                    Text("\(expenseViewModel.formatSum(from: expense.payAmount == -1 ? Double.nan : expense.payAmount, to: 2))")
-                                        .font(.subhead2_1)
-                                        .padding(.leading, 3 )
-                                }
-                                let currencyCodeName = Currency.getCurrencyCodeName(of: Int(expense.currency))
-                                let exchangeRate = exchangeRatehandler.getExchangeRateFromKRW(currencyCode: currencyCodeName) ?? -100
-                                let payAmount = expense.payAmount == -1 ? Double.nan : expense.payAmount * exchangeRate
-                                let formattedPayAmount = expenseViewModel.formatSum(from: payAmount, to: 0)
-                                Text("(\(formattedPayAmount)원)")
-                                    .font(.caption2)
-                                    .foregroundStyle(.gray200)
-                                    .padding(.top, 4 )
                             }
                         }
                     }

--- a/UMM/View/Expense/AllExpenseDetailView.swift
+++ b/UMM/View/Expense/AllExpenseDetailView.swift
@@ -42,6 +42,16 @@ struct AllExpenseDetailView: View {
             expenseViewModel.filteredAllExpensesForDetail = self.getFilteredAllExpenses(selectedTravel: selectedTravel ?? Travel(context: viewContext), selectedPaymentMethod: selectedPaymentMethod, selectedCategory: selectedCategory, selectedCountry: selectedCountry)
             currencyAndSums = expenseViewModel.calculateCurrencySums(from: expenseViewModel.filteredAllExpensesForDetail)
         }
+        .toolbar(.hidden, for: .tabBar)
+        .toolbarBackground(.white, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: backButtonView)
+    }
+    
+    private var backButtonView: some View {
+        Image(systemName: "chevron.left")
+            .imageScale(.large)
+            .foregroundColor(Color.black)
     }
     
     private var paymentModal: some View {
@@ -183,7 +193,7 @@ struct AllExpenseDetailView: View {
                                 given_location: expense.location,
                                 given_id: expense.id
                             )
-                                .environmentObject(mainVM) // ^^^
+                            .environmentObject(mainVM) // ^^^
                         } label : {
                             HStack(alignment: .center, spacing: 0) {
                                 Image(ExpenseInfoCategory(rawValue: Int(expense.category))?.modalImageString ?? "nil")

--- a/UMM/View/Expense/AllExpenseDetailView.swift
+++ b/UMM/View/Expense/AllExpenseDetailView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct AllExpenseDetailView: View {
     @StateObject var expenseViewModel = ExpenseViewModel()
+    @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var mainVM: MainViewModel
     
     var selectedTravel: Travel?
     var selectedCategory: Int64
@@ -17,7 +19,6 @@ struct AllExpenseDetailView: View {
     @State private var currencyAndSums: [CurrencyAndSum] = []
     @State private var isPaymentModalPresented = false
     var sumPaymentMethod: Double
-    @EnvironmentObject var mainVM: MainViewModel
     let exchangeRatehandler = ExchangeRateHandler.shared
     let currencyInfoModel = CurrencyInfoModel.shared.currencyResult
     let dateGapHandler = DateGapHandler.shared
@@ -49,9 +50,13 @@ struct AllExpenseDetailView: View {
     }
     
     private var backButtonView: some View {
-        Image(systemName: "chevron.left")
-            .imageScale(.large)
-            .foregroundColor(Color.black)
+        Button {
+            presentationMode.wrappedValue.dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .imageScale(.large)
+                .foregroundColor(Color.black)
+        }
     }
     
     private var paymentModal: some View {

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -157,10 +157,13 @@ struct TodayExpenseDetailView: View {
                     ManualRecordInExpenseView(
                         given_wantToActivateAutoSaveTimer: false,
                         given_payAmount: expense.payAmount,
+                        given_currency: Int(expense.currency),
                         given_info: expense.info,
                         given_infoCategory: ExpenseInfoCategory(rawValue: Int(expense.category)) ?? .unknown,
                         given_paymentMethod: PaymentMethod(rawValue: Int(expense.paymentMethod)) ?? .unknown,
-                        given_soundRecordData: expense.voiceRecordFile)
+                        given_soundRecordData: expense.voiceRecordFile,
+                        given_expense: expense
+                    )
                         .environmentObject(mainVM) // ^^^
                 } label: {
                     HStack(alignment: .center, spacing: 0) {

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -162,7 +162,11 @@ struct TodayExpenseDetailView: View {
                         given_infoCategory: ExpenseInfoCategory(rawValue: Int(expense.category)) ?? .unknown,
                         given_paymentMethod: PaymentMethod(rawValue: Int(expense.paymentMethod)) ?? .unknown,
                         given_soundRecordData: expense.voiceRecordFile,
-                        given_expense: expense
+                        given_expense: expense,
+                        given_payDate: expense.payDate,
+                        given_country: Int(expense.country),
+                        given_location: expense.location,
+                        given_id: expense.id
                     )
                         .environmentObject(mainVM) // ^^^
                 } label: {

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -45,6 +45,16 @@ struct TodayExpenseDetailView: View {
             
             print("TEDV | selectedPaymentMethod: \(selectedPaymentMethod)")
         }
+        .toolbar(.hidden, for: .tabBar)
+        .toolbarBackground(.white, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: backButtonView)
+    }
+    
+    private var backButtonView: some View {
+        Image(systemName: "chevron.left")
+            .imageScale(.large)
+            .foregroundColor(Color.black)
     }
     
     private var paymentModal: some View {

--- a/UMM/View/Expense/TodayExpenseDetailView.swift
+++ b/UMM/View/Expense/TodayExpenseDetailView.swift
@@ -10,6 +10,8 @@ import CoreData
 
 struct TodayExpenseDetailView: View {
     @StateObject var expenseViewModel = ExpenseViewModel()
+    @EnvironmentObject var mainVM: MainViewModel
+    @Environment(\.presentationMode) var presentationMode
     
     var selectedTravel: Travel?
     var selectedDate: Date
@@ -18,7 +20,6 @@ struct TodayExpenseDetailView: View {
     @State private var currencyAndSums: [CurrencyAndSum] = []
     var sumPaymentMethod: Double
     @State private var isPaymentModalPresented = false
-    @EnvironmentObject var mainVM: MainViewModel
     let exchangeRatehandler = ExchangeRateHandler.shared
     let currencyInfoModel = CurrencyInfoModel.shared.currencyResult
     let countryInfoModel = CountryInfoModel.shared.countryResult
@@ -52,9 +53,13 @@ struct TodayExpenseDetailView: View {
     }
     
     private var backButtonView: some View {
-        Image(systemName: "chevron.left")
-            .imageScale(.large)
-            .foregroundColor(Color.black)
+        Button {
+            presentationMode.wrappedValue.dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .imageScale(.large)
+                .foregroundColor(Color.black)
+        }
     }
     
     private var paymentModal: some View {

--- a/UMM/View/Record/ManualRecordInExpenseView.swift
+++ b/UMM/View/Record/ManualRecordInExpenseView.swift
@@ -259,30 +259,30 @@ struct ManualRecordInExpenseView: View {
             fraction0NumberFormatter.maximumFractionDigits = 0
             
             // MARK: - timer
-            if viewModel.wantToActivateAutoSaveTimer && (viewModel.payAmount != -1 || viewModel.info != nil) {
-                viewModel.secondCounter = 8
-                viewModel.autoSaveTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
-                    if let secondCounter = viewModel.secondCounter {
-                        if secondCounter > 1 {
-                            viewModel.secondCounter! -= 1
-                        } else {
-                            if viewModel.payAmount != -1 || viewModel.info != nil {
-                                viewModel.secondCounter = nil
-                                viewModel.save()
-                                if mainVM.chosenTravelInManualRecord != nil {
-                                    mainVM.selectedTravel = mainVM.chosenTravelInManualRecord
-                                }
-                                viewModel.deleteUselessAudioFiles()
-                                self.dismiss()
-                                timer.invalidate()
-                            } else {
-                                viewModel.secondCounter = nil
-                                timer.invalidate()
-                            }
-                        }
-                    }
-                }
-            }
+//            if viewModel.wantToActivateAutoSaveTimer && (viewModel.payAmount != -1 || viewModel.info != nil) {
+//                viewModel.secondCounter = 8
+//                viewModel.autoSaveTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+//                    if let secondCounter = viewModel.secondCounter {
+//                        if secondCounter > 1 {
+//                            viewModel.secondCounter! -= 1
+//                        } else {
+//                            if viewModel.payAmount != -1 || viewModel.info != nil {
+//                                viewModel.secondCounter = nil
+//                                viewModel.save()
+//                                if mainVM.chosenTravelInManualRecord != nil {
+//                                    mainVM.selectedTravel = mainVM.chosenTravelInManualRecord
+//                                }
+//                                viewModel.deleteUselessAudioFiles()
+//                                self.dismiss()
+//                                timer.invalidate()
+//                            } else {
+//                                viewModel.secondCounter = nil
+//                                timer.invalidate()
+//                            }
+//                        }
+//                    }
+//                }
+//            }
         }
         .onAppear(perform: UIApplication.shared.hideKeyboard)
         .onDisappear {
@@ -446,16 +446,10 @@ struct ManualRecordInExpenseView: View {
                     if viewModel.soundRecordData != nil {
                         if !viewModel.playingRecordSound {
                             if let soundRecordData = viewModel.soundRecordData {
-                                
-                                let audioURL = FileManager.default.temporaryDirectory.appendingPathComponent("VOICE \(Date().toString(dateFormat: "dd-MM-YY HH:mm:ss")).m4a")
-                                do {
-                                    try soundRecordData.write(to: audioURL)
-                                } catch {
-                                    print("Failed to write audioData to \(audioURL): \(error)")
-                                }
-                                
-                                viewModel.startPlayingAudio(url: audioURL)
+                                viewModel.startPlayingAudio(data: soundRecordData)
                                 viewModel.playingRecordSound = true
+                            } else {
+                                print("ManualRecordInExpenseView | payAmountBlockView | Failed to unwrapping soundRecordData")
                             }
                         } else {
                             viewModel.stopPlayingAudio()

--- a/UMM/View/Record/ManualRecordInExpenseView.swift
+++ b/UMM/View/Record/ManualRecordInExpenseView.swift
@@ -25,6 +25,10 @@ struct ManualRecordInExpenseView: View {
     let given_paymentMethod: PaymentMethod
     let given_soundRecordData: Data?
     let given_expense: Expense
+    let given_payDate: Date?
+    let given_country: Int
+    let given_location: String?
+    let given_id: ObjectIdentifier
     
     var body: some View {
         ZStack {
@@ -122,6 +126,10 @@ struct ManualRecordInExpenseView: View {
             viewModel.paymentMethod = given_paymentMethod
             viewModel.soundRecordData = given_soundRecordData
             viewModel.currency = given_currency
+            viewModel.payDate = given_payDate ?? Date()
+            viewModel.country = given_country
+            viewModel.locationExpression = given_location ?? ""
+            viewModel.expenseId = given_id
 
             DispatchQueue.main.async {
                 MainViewModel.shared.chosenTravelInManualRecord = MainViewModel.shared.selectedTravel
@@ -194,9 +202,9 @@ struct ManualRecordInExpenseView: View {
             viewModel.soundRecordData = given_soundRecordData
 
             viewModel.getLocation()
-            viewModel.country = viewModel.currentCountry
-            viewModel.countryExpression = CountryInfoModel.shared.countryResult[viewModel.currentCountry]?.koreanNm ?? "알 수 없음"
-            viewModel.locationExpression = viewModel.currentLocation
+//            viewModel.country = viewModel.currentCountry
+            viewModel.countryExpression = CountryInfoModel.shared.countryResult[viewModel.country]?.koreanNm ?? "알 수 없음"
+//            viewModel.locationExpression = viewModel.currentLocation
             
             if !viewModel.otherCountryCandidateArray.contains(viewModel.country) {
                 viewModel.otherCountryCandidateArray.append(viewModel.country)

--- a/UMM/View/Record/ManualRecordInExpenseView.swift
+++ b/UMM/View/Record/ManualRecordInExpenseView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import CoreLocation
 
 struct ManualRecordInExpenseView: View {
-    @ObservedObject var viewModel = ManualRecordInExpenseViewModel()
+    @StateObject var viewModel = ManualRecordInExpenseViewModel()
     @EnvironmentObject var mainVM: MainViewModel
     @Environment(\.dismiss) var dismiss
     let viewContext = PersistenceController.shared.container.viewContext
@@ -19,10 +19,12 @@ struct ManualRecordInExpenseView: View {
     
     let given_wantToActivateAutoSaveTimer: Bool
     let given_payAmount: Double
+    let given_currency: Int
     let given_info: String?
     let given_infoCategory: ExpenseInfoCategory
     let given_paymentMethod: PaymentMethod
     let given_soundRecordData: Data?
+    let given_expense: Expense
     
     var body: some View {
         ZStack {
@@ -94,12 +96,14 @@ struct ManualRecordInExpenseView: View {
             Text("현재 화면의 정보를 모두 초기화하고 이전 화면으로 돌아갈까요?")
         }
         .onAppear {
-            print("given_info: \(given_info)")
-            print("given_payAmount: \(given_payAmount)")
-            print("given_paymentMethod: \(given_paymentMethod)")
-            print("given_infoCategory: \(given_infoCategory)")
-            print("given_soundRecordData: \(given_soundRecordData)")
             print("given_wantToActivateAutoSaveTimer: \(given_wantToActivateAutoSaveTimer)")
+            print("given_payAmount: \(given_payAmount)")
+            print("given_currency: \(given_currency)")
+            print("given_info: \(given_info)")
+            print("given_infoCategory: \(given_infoCategory)")
+            print("given_paymentMethod: \(given_paymentMethod)")
+            print("given_soundRecordData: \(given_soundRecordData)")
+            print("given_expense: \(given_expense)")
             viewModel.wantToActivateAutoSaveTimer = given_wantToActivateAutoSaveTimer
             
             viewModel.payAmount = given_payAmount
@@ -117,6 +121,7 @@ struct ManualRecordInExpenseView: View {
             viewModel.category = given_infoCategory
             viewModel.paymentMethod = given_paymentMethod
             viewModel.soundRecordData = given_soundRecordData
+            viewModel.currency = given_currency
 
             DispatchQueue.main.async {
                 MainViewModel.shared.chosenTravelInManualRecord = MainViewModel.shared.selectedTravel
@@ -133,6 +138,10 @@ struct ManualRecordInExpenseView: View {
             } else {
                 viewModel.participantTupleArray = [("나", true)]
             }
+            
+            // 초기값
+            MainViewModel.shared.chosenTravelInManualRecord = given_expense.travel
+            
             var expenseArray: [Expense] = []
             if let chosenTravel = MainViewModel.shared.chosenTravelInManualRecord {
                 do {
@@ -147,8 +156,10 @@ struct ManualRecordInExpenseView: View {
                     print("error fetching expenses: \(error.localizedDescription)")
                 }
             }
+            
             viewModel.otherCountryCandidateArray = Array(Set(expenseArray.map { Int($0.country) })).sorted()
 
+            // MARK: - ^^^
             if viewModel.currentCountry == 3 {
                 viewModel.currencyCandidateArray = [4, 0]
             } else {
@@ -191,16 +202,16 @@ struct ManualRecordInExpenseView: View {
                 viewModel.otherCountryCandidateArray.append(viewModel.country)
             }
             
-            let stringCurrency = CountryInfoModel.shared.countryResult[viewModel.currentCountry]?.relatedCurrencyArray.first ?? "Unknown"
+//            let stringCurrency = CountryInfoModel.shared.countryResult[viewModel.currentCountry]?.relatedCurrencyArray.first ?? "Unknown"
             
-            viewModel.currency =  4 // 미국 달러
+//            viewModel.currency =  4 // 미국 달러
             
-            for tuple in CurrencyInfoModel.shared.currencyResult where tuple.key != -1 {
-                if tuple.value.isoCodeNm == stringCurrency {
-                    viewModel.currency = tuple.key
-                    break
-                }
-            }
+//            for tuple in CurrencyInfoModel.shared.currencyResult where tuple.key != -1 {
+//                if tuple.value.isoCodeNm == stringCurrency {
+//                    viewModel.currency = tuple.key
+//                    break
+//                }
+//            }
             
             if viewModel.currentCountry == 3 { // 미국
                 viewModel.currencyCandidateArray = [4, 0]

--- a/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
+++ b/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
@@ -290,7 +290,7 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
     
     // MARK: - voice
     
-    private var audioPlayer: AVAudioPlayer?
+    var audioPlayer: AVAudioPlayer?
     
     func startPlayingAudio(url: URL) {
         
@@ -308,6 +308,43 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
             audioPlayer?.prepareToPlay()
             audioPlayer?.play()
             
+        } catch {
+            print("Playing Failed")
+        }
+    }
+    
+    func startPlayingAudio(data: Data) {
+        let tempDirectoryURL = FileManager.default.temporaryDirectory
+        let fileURL = tempDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("m4a")
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("Failed to save file: \(error)")
+            return
+        }
+
+        let playSession = AVAudioSession.sharedInstance()
+
+        do {
+            try playSession.overrideOutputAudioPort(AVAudioSession.PortOverride.speaker)
+        } catch {
+            print("Playing failed in Device")
+        }
+        
+        do {
+            try playSession.setCategory(.playback)
+            try playSession.setActive(true)
+        } catch {
+            print("Setting category to AVAudioSessionCategoryPlayback failed.")
+        }
+
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: fileURL)
+            audioPlayer?.delegate = self
+            audioPlayer?.prepareToPlay()
+            audioPlayer?.play()
+
         } catch {
             print("Playing Failed")
         }

--- a/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
+++ b/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
@@ -315,7 +315,8 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
     
     func startPlayingAudio(data: Data) {
         let tempDirectoryURL = FileManager.default.temporaryDirectory
-        let fileURL = tempDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("m4a")
+        let randomID = UUID().uuidString
+        let fileURL = tempDirectoryURL.appendingPathComponent(randomID).appendingPathExtension("m4a")
 
         do {
             try data.write(to: fileURL, options: .atomic)
@@ -344,7 +345,6 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
             audioPlayer?.delegate = self
             audioPlayer?.prepareToPlay()
             audioPlayer?.play()
-
         } catch {
             print("Playing Failed")
         }

--- a/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
+++ b/UMM/ViewModel/ManualRecordInExpenseViewModel.swift
@@ -39,6 +39,7 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
     
     let viewContext = PersistenceController.shared.container.viewContext
     let exchangeHandler = ExchangeRateHandler.shared
+    var expenseId = ObjectIdentifier(NSObject())
     
     // MARK: - 위치 정보
     private var locationManager: CLLocationManager?
@@ -241,8 +242,16 @@ final class ManualRecordInExpenseViewModel: NSObject, ObservableObject {
     }
         
     func save() {
+        var expense: Expense?
+        do {
+            expense = try viewContext.fetch(Expense.fetchRequest()).filter { expense in
+                return expense.id == expenseId
+            }.first
+        } catch let error {
+            print("\(error.localizedDescription)")
+        }
+        guard let expense = expense else { return }
         
-        let expense = Expense(context: viewContext)
         expense.category = Int64(category.rawValue)
         expense.country = Int64(country)
         expense.currency = Int64(currency)


### PR DESCRIPTION
## 👀 이슈
- #218 

## 💡 작업 내용
- TodayExpenseDetailView: ManualRecordInExpenseView 연결
- TodayExpenseDetailView: 데이터 조회, 수정, 저장 구현
- AllExpenseDetailView: ManualRecordInExpenseView 연결
- AllExpenseDetailView: 데이터 조회, 수정, 저장 구현
- DetailView에서 백 버튼에 "뒤로" 텍스트 삭제

## 📱스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2023-11-09 at 10 27 44](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/102353544/567d63da-0a36-4d58-a5ef-79047ab4337b)
"DetailView에서 백 버튼에 "뒤로" 텍스트 삭제"에 대한 영상입니다.

## 🚨 참고 사항
ManualRecordViewModel에 data를 인자로 받는 startPlayingAudio() 함수를 작성했습니다. @oliver-or-not 

## (Optional) 🤔 고민한 점
CoreData에 저장된 오디오 파일을 재생하는 데에 어려움을 겪었습니다.
@oliver-or-not 가 사용하는 함수는 임시로 생성한 File Manager를 URL로 접근해서 실행하는 방식입니다.
제가 필요한 방식은 Binary data 타입을 저장된 오디오 파일을 즉시 실행하는 방식입니다.
하지만 즉시 실행하는 방식이 어려웠습니다.
현재 구현한 방식은 data를 받아서, 임시 URL을 생성해서 재생하는 방식입니다.

앞으로 개선 방향은 2가지 있습니다.
1. Binary Data를 즉시 실행하도록 개선
2. 생성한 임시 URL을 적절한 시점에 삭제하도록 개선

