### PR TITLE
⚡️🎨[#216][#222] Travel 관련 뷰들의 수정사항을 반영합니다.

### DIFF
--- a/UMM/View/Record/InterimOncomingView.swift
+++ b/UMM/View/Record/InterimOncomingView.swift
@@ -127,9 +127,13 @@ struct InterimOncomingView: View {
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                if let endDate = onComingTravel?[index].endDate {
+                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                } else {
+                                                    Text("")
+                                                }
                                             }
                                             .padding(.horizontal, 8)
                                             .padding(.bottom, 8)
@@ -281,9 +285,13 @@ struct InterimOncomingView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(dateGapHandler.convertBeforeShowing(date: onComingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                                    .font(.caption2)
-                                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                                if let endDate = onComingTravel?[index].endDate {
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                        .font(.caption2)
+                                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                                } else {
+                                                                    Text("")
+                                                                }
                                                             }
                                                             .padding(.horizontal, 8)
                                                             .padding(.bottom, 8)

--- a/UMM/View/Record/InterimOncomingView.swift
+++ b/UMM/View/Record/InterimOncomingView.swift
@@ -142,7 +142,7 @@ struct InterimOncomingView: View {
                                         RoundedRectangle(cornerRadius: 10)
                                             .frame(width: 110, height: 80)
                                             .foregroundStyle(.gray100)
-                                            .opacity(chosenTravel == onComingTravel?[index] ? 0.0 : 0.3)
+                                            .opacity(chosenTravel == onComingTravel?[index] ? 0.0 : 0.4)
                                     }
                                     .frame(width: 110, height: 80)
                                     .onAppear {
@@ -178,6 +178,7 @@ struct InterimOncomingView: View {
                                     }
                                 }
                                 Text(onComingTravel?[index].name ?? "제목 미정")
+                                    .foregroundStyle(chosenTravel == onComingTravel?[index] ? Color.black : Color.gray300)
                                     .font(.subhead1)
                                     .lineLimit(1)
                             }
@@ -300,7 +301,7 @@ struct InterimOncomingView: View {
                                                         RoundedRectangle(cornerRadius: 10)
                                                             .frame(width: 110, height: 80)
                                                             .foregroundStyle(.gray100)
-                                                            .opacity(chosenTravel == onComingTravel?[index] ? 0.0 : 0.3)
+                                                            .opacity(chosenTravel == onComingTravel?[index] ? 0.0 : 0.4)
                                                     }
                                                     .frame(width: 110, height: 80)
                                                     .onAppear {
@@ -337,6 +338,7 @@ struct InterimOncomingView: View {
                                                 }
                                                 
                                                 Text(onComingTravel?[index].name ?? "제목 미정")
+                                                    .foregroundStyle(chosenTravel == onComingTravel?[index] ? Color.black : Color.gray300)
                                                     .font(.subhead1)
                                                     .lineLimit(1)
                                             }

--- a/UMM/View/Record/InterimPastView.swift
+++ b/UMM/View/Record/InterimPastView.swift
@@ -142,7 +142,7 @@ struct InterimPastView: View {
                                         RoundedRectangle(cornerRadius: 10)
                                             .frame(width: 110, height: 80)
                                             .foregroundStyle(.gray100)
-                                            .opacity(chosenTravel == previousTravel?[index] ? 0.0 : 0.3)
+                                            .opacity(chosenTravel == previousTravel?[index] ? 0.0 : 0.4)
                                     }
                                     .frame(width: 110, height: 80)
                                     .onAppear {
@@ -179,6 +179,7 @@ struct InterimPastView: View {
                                     }
                                 }
                                 Text(previousTravel?[index].name ?? "제목 미정")
+                                    .foregroundStyle(chosenTravel == previousTravel?[index] ? Color.black : Color.gray300)
                                     .font(.subhead1)
                                     .lineLimit(1)
                             }
@@ -302,7 +303,7 @@ struct InterimPastView: View {
                                                         RoundedRectangle(cornerRadius: 10)
                                                             .frame(width: 110, height: 80)
                                                             .foregroundStyle(.gray100)
-                                                            .opacity(chosenTravel == previousTravel?[index] ? 0.0 : 0.3)
+                                                            .opacity(chosenTravel == previousTravel?[index] ? 0.0 : 0.4)
                                                     }
                                                     .frame(width: 110, height: 80)
                                                     .onAppear {
@@ -339,6 +340,7 @@ struct InterimPastView: View {
                                                     }
                                                 }
                                                 Text(previousTravel?[index].name ?? "제목 미정")
+                                                    .foregroundStyle(chosenTravel == previousTravel?[index] ? Color.black : Color.gray300)
                                                     .font(.subhead1)
                                                     .lineLimit(1)
                                             }

--- a/UMM/View/Record/InterimPastView.swift
+++ b/UMM/View/Record/InterimPastView.swift
@@ -119,7 +119,7 @@ struct InterimPastView: View {
                                             
                                             // Doris : 날짜 표시
                                             VStack(alignment: .leading, spacing: 0) {
-                                                HStack {
+                                                HStack(spacing: 0) {
                                                     Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                     
                                                     Text("~")
@@ -127,9 +127,13 @@ struct InterimPastView: View {
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                if let endDate = previousTravel?[index].endDate {
+                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                } else {
+                                                    Text("")
+                                                }
                                             }
                                             .padding(.horizontal, 8)
                                             .padding(.bottom, 8)
@@ -283,9 +287,13 @@ struct InterimPastView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                                    .font(.caption2)
-                                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                                if let endDate = previousTravel?[index].endDate {
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                        .font(.caption2)
+                                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                                } else {
+                                                                    Text("")
+                                                                }
                                                             }
                                                             .padding(.horizontal, 8)
                                                             .padding(.bottom, 8)

--- a/UMM/View/Record/InterimProceedingView.swift
+++ b/UMM/View/Record/InterimProceedingView.swift
@@ -142,7 +142,7 @@ struct InterimProceedingView: View {
                                         RoundedRectangle(cornerRadius: 10)
                                             .frame(width: 110, height: 80)
                                             .foregroundStyle(.gray100)
-                                            .opacity(chosenTravel == nowTravel?[index] ? 0.0 : 0.3)
+                                            .opacity(chosenTravel == nowTravel?[index] ? 0.0 : 0.4)
                                     }
                                     .frame(width: 110, height: 80)
                                     .onAppear {
@@ -179,6 +179,7 @@ struct InterimProceedingView: View {
                                 }
                                 
                                 Text(nowTravel?[index].name ?? "제목 미정")
+                                    .foregroundStyle(chosenTravel == nowTravel?[index] ? Color.black : Color.gray300)
                                     .font(.subhead1)
                                     .lineLimit(1)
                             }
@@ -303,7 +304,7 @@ struct InterimProceedingView: View {
                                                           RoundedRectangle(cornerRadius: 10)
                                                               .frame(width: 110, height: 80)
                                                               .foregroundStyle(.gray100)
-                                                              .opacity(chosenTravel == nowTravel?[index] ? 0.0 : 0.3)
+                                                              .opacity(chosenTravel == nowTravel?[index] ? 0.0 : 0.4)
                                                       }
                                                       .frame(width: 110, height: 80)
                                                       .onAppear {
@@ -330,6 +331,7 @@ struct InterimProceedingView: View {
                                                       }
                                                   }
                                                   Text(nowTravel?[index].name ?? "제목 미정")
+                                                      .foregroundStyle(chosenTravel == nowTravel?[index] ? Color.black : Color.gray300)
                                                       .font(.subhead1)
                                                       .lineLimit(1)
                                               }

--- a/UMM/View/Record/InterimProceedingView.swift
+++ b/UMM/View/Record/InterimProceedingView.swift
@@ -127,9 +127,13 @@ struct InterimProceedingView: View {
                                                 .font(.caption2)
                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                 
-                                                Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                if let endDate = nowTravel?[index].endDate {
+                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                        .font(.caption2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                } else {
+                                                    Text("")
+                                                }
                                             }
                                             .padding(.horizontal, 8)
                                             .padding(.bottom, 8)
@@ -276,7 +280,7 @@ struct InterimProceedingView: View {
                                                               
                                                               // Doris : 날짜 표시
                                                               VStack(alignment: .leading, spacing: 0) {
-                                                                  HStack {
+                                                                  HStack(spacing: 0) {
                                                                       Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
                                                                       
                                                                       Text("~")
@@ -284,9 +288,13 @@ struct InterimProceedingView: View {
                                                                   .font(.caption2)
                                                                   .foregroundStyle(Color.white.opacity(0.75))
                                                                   
-                                                                  Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                                      .font(.caption2)
-                                                                      .foregroundStyle(Color.white.opacity(0.75))
+                                                                  if let endDate = nowTravel?[index].endDate {
+                                                                      Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                          .font(.caption2)
+                                                                          .foregroundStyle(Color.white.opacity(0.75))
+                                                                  } else {
+                                                                      Text("")
+                                                                  }
                                                               }
                                                               .padding(.horizontal, 8)
                                                               .padding(.bottom, 8)

--- a/UMM/View/Record/InterimRecordView.swift
+++ b/UMM/View/Record/InterimRecordView.swift
@@ -60,8 +60,6 @@ struct InterimRecordView: View {
             // ViewModel의 Save함수가 실행됨
             DispatchQueue.main.async {
                 viewModel.update()
-//                print("xxxxxx : chose Expense", defaultExpense?[selectedTravelIndex])
-//                print("xxxxxx", viewModel.chosenExpense?.travel?.name)
             }
         }
     }

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -51,10 +51,9 @@ struct AddMemberView: View {
                 if participantArr.count > 0 {
                     participantCnt -= 1
                     let updateArr = Array(participantArr.dropLast())
-                    viewModel.participantArr = ["me"] + updateArr
+                    viewModel.participantArr = updateArr
                 } else {
-                    
-                    viewModel.participantArr = ["me"] + participantArr
+                    viewModel.participantArr = participantArr
                 }
                 viewModel.startDate = (startDate ?? Date()).local000().convertBeforeSaving()
 //                if let endDate = viewModel.endDate {

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -65,9 +65,9 @@ struct AddMemberView: View {
                 
                 // 여행 이름
                 if let arr = viewModel.participantArr {
-                    if arr.count == 2 {
+                    if arr.count == 1 {
                         viewModel.travelName = "me 나, \(participantArr[0])"
-                    } else if arr.count <= 1 {
+                    } else if arr.count < 1 {
                         viewModel.travelName = "나의 여행"
                     } else {
                         viewModel.travelName = "\(participantArr[0]) 외 \(participantCnt+1)명의 여행"

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -57,11 +57,12 @@ struct AddMemberView: View {
                     viewModel.participantArr = ["me"] + participantArr
                 }
                 viewModel.startDate = (startDate ?? Date()).local000().convertBeforeSaving()
-                if let endDate = viewModel.endDate {
-                    viewModel.endDate = endDate.local235959().convertBeforeSaving()
-                } else {
-                    viewModel.endDate = nil
-                }
+//                if let endDate = viewModel.endDate {
+//                    viewModel.endDate = endDate.local235959().convertBeforeSaving()
+//                } else {
+//                    viewModel.endDate = nil
+//                }
+                viewModel.endDate = dateGapHandler.convertBeforeSaving(date: endDate ?? Date())
                 
                 // 여행 이름
                 if let arr = viewModel.participantArr {

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -56,8 +56,12 @@ struct AddMemberView: View {
                     
                     viewModel.participantArr = ["me"] + participantArr
                 }
-                viewModel.startDate = dateGapHandler.convertBeforeSaving(date: startDate ?? Date())
-                viewModel.endDate = dateGapHandler.convertBeforeSaving(date: endDate ?? Date())
+                viewModel.startDate = (startDate ?? Date()).local000().convertBeforeSaving()
+                if let endDate = viewModel.endDate {
+                    viewModel.endDate = endDate.local235959().convertBeforeSaving()
+                } else {
+                    viewModel.endDate = nil
+                }
                 
                 // 여행 이름
                 if let arr = viewModel.participantArr {

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -354,12 +354,12 @@ struct AddTravelView: View {
             }
         }
         
-        // 시작일과 종료일
-        private func makeSquare(date: Date) -> Bool {
-            if let startDate = viewModel.startDate, let endDate = viewModel.endDate {
-                return date == startDate || date == endDate
+        private func isEndDateSelected(date: Date?) -> Bool {
+            if date == nil {
+                return false
+            } else {
+                return true
             }
-            return false
         }
         
         var body: some View {
@@ -398,47 +398,20 @@ struct AddTravelView: View {
                                         .frame(width: 45, height: 41)
                                         .foregroundStyle(Color.white)
                                 }
-                            } else if makeSquare(date: self.date!) {
-                                ZStack {
-                                    ZStack {
-                                        Rectangle()
-                                            .frame(width: 80, height: 33)
-                                            .foregroundStyle(
-                                                LinearGradient(
-                                                    gradient: Gradient(colors: [Color.mainPink.opacity(1), Color.mainPink.opacity(0)]),
-                                                    startPoint: .leading,
-                                                    endPoint: .trailing
-                                                )
-                                            )
-                                            .offset(x: 40)
-                                        
-                                        Circle()
-                                            .frame(width: 33, height: 33)
-                                            .overlay(
-                                                Circle()
-                                                    .stroke(Color.white)
-                                                    .fill(Color.mainPink)
-                                            )
-                                    }
-                                    
-                                    Text(String(day))
-                                        .padding(9.81)
-                                        .font(.calendar2)
-                                        .frame(width: 45, height: 41)
-                                        .foregroundStyle(Color.white)
-                                }
                             } else if viewModel.startDateToString(in: viewModel.startDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.startDateToString(in: self.date! - 1) {
                                 ZStack {
-                                    ZStack {
-                                        
-                                        Circle()
-                                            .frame(width: 33, height: 33)
-                                            .overlay(
-                                                Circle()
-                                                    .stroke(Color.white)
-                                                    .fill(Color.mainPink)
-                                            )
-                                    }
+                                    Rectangle()
+                                        .frame(width: 33, height: 33)
+                                        .foregroundStyle(isEndDateSelected(date: viewModel.endDate) ? Color(0xFF8298) : Color.clear)
+                                        .offset(x: 20)
+                                    
+                                    Circle()
+                                        .frame(width: 33, height: 33)
+                                        .overlay(
+                                            Circle()
+                                                .stroke(Color.white)
+                                                .fill(Color.mainPink)
+                                        )
                                     
                                     Text(String(day))
                                         .padding(9.81)
@@ -448,6 +421,11 @@ struct AddTravelView: View {
                                 }
                             } else if viewModel.endDateToString(in: viewModel.endDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.endDateToString(in: self.date! - 1) {
                                 ZStack {
+                                    Rectangle()
+                                        .frame(width: 33, height: 33)
+                                        .foregroundStyle(Color(0xFF8298))
+                                        .offset(x: -20)
+                                    
                                     Circle()
                                         .frame(width: 33, height: 33)
                                         .overlay(
@@ -468,12 +446,12 @@ struct AddTravelView: View {
                                     Text(String(day))
                                         .padding(9.81)
                                         .font(.calendar2)
-                                        .foregroundStyle(Color.black)
+                                        .foregroundStyle(Color.white)
                                         .frame(width: 47) // 45
                                         .background(
                                             Rectangle()
-                                                .foregroundStyle(Color(0xFBEFFB))
-                                                .frame(width: 50, height: 28)
+                                                .foregroundStyle(Color(0xFF8298))
+                                                .frame(width: 50, height: 33)
                                         )
                                         .foregroundStyle(textColor)
                                 }

--- a/UMM/View/Travel/AddTravelView.swift
+++ b/UMM/View/Travel/AddTravelView.swift
@@ -401,9 +401,9 @@ struct AddTravelView: View {
                             } else if viewModel.startDateToString(in: viewModel.startDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.startDateToString(in: self.date! - 1) {
                                 ZStack {
                                     Rectangle()
-                                        .frame(width: 33, height: 33)
-                                        .foregroundStyle(isEndDateSelected(date: viewModel.endDate) ? Color(0xFF8298) : Color.clear)
-                                        .offset(x: 20)
+                                        .frame(width: 28, height: 33)
+                                        .foregroundStyle(isEndDateSelected(date: viewModel.endDate) ? Color(0xFFCCD5) : Color.clear)
+                                        .offset(x: 15)
                                     
                                     Circle()
                                         .frame(width: 33, height: 33)
@@ -416,27 +416,6 @@ struct AddTravelView: View {
                                     Text(String(day))
                                         .padding(9.81)
                                         .font(.calendar2)
-                                        .frame(width: 45, height: 41)
-                                        .foregroundStyle(Color.white)
-                                }
-                            } else if viewModel.endDateToString(in: viewModel.endDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.endDateToString(in: self.date! - 1) {
-                                ZStack {
-                                    Rectangle()
-                                        .frame(width: 33, height: 33)
-                                        .foregroundStyle(Color(0xFF8298))
-                                        .offset(x: -20)
-                                    
-                                    Circle()
-                                        .frame(width: 33, height: 33)
-                                        .overlay(
-                                            Circle()
-                                                .stroke(Color.white)
-                                                .fill(Color.mainPink)
-                                        )
-                                    
-                                    Text(String(day))
-                                        .font(.calendar2)
-                                        .padding(9.81)
                                         .frame(width: 45, height: 41)
                                         .foregroundStyle(Color.white)
                                 }
@@ -450,10 +429,31 @@ struct AddTravelView: View {
                                         .frame(width: 47) // 45
                                         .background(
                                             Rectangle()
-                                                .foregroundStyle(Color(0xFF8298))
+                                                .foregroundStyle(Color(0xFFCCD5))
                                                 .frame(width: 50, height: 33)
                                         )
                                         .foregroundStyle(textColor)
+                                }
+                            } else if viewModel.endDateToString(in: viewModel.endDate ?? Date(timeIntervalSinceReferenceDate: 8)) == viewModel.endDateToString(in: self.date! - 1) {
+                                ZStack {
+                                    Rectangle()
+                                        .frame(width: 28, height: 33)
+                                        .foregroundStyle(Color(0xFFCCD5))
+                                        .offset(x: -15)
+                                    
+                                    Circle()
+                                        .frame(width: 33, height: 33)
+                                        .overlay(
+                                            Circle()
+                                                .stroke(Color.white)
+                                                .fill(Color.mainPink)
+                                        )
+                                    
+                                    Text(String(day))
+                                        .font(.calendar2)
+                                        .padding(9.81)
+                                        .frame(width: 45, height: 41)
+                                        .foregroundStyle(Color.white)
                                 }
                             }
                         }

--- a/UMM/View/Travel/CompleteAddTravelView.swift
+++ b/UMM/View/Travel/CompleteAddTravelView.swift
@@ -52,17 +52,13 @@ struct CompleteAddTravelView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 viewModel.fetchTravel()
                 self.selectedTravel = viewModel.filterTravelByID(selectedTravelID: travelID)
-//                if let firstParticipant = selectedTravel?.first?.participantArray?.first {
-//                    self.travelNM = firstParticipant + "외" + "\(String(describing: selectedTravel?.first?.participantArray?.count))명의 여행"
-//                } else {
-//                    self.travelNM = "나의 여행"
-//                }
                 self.travelNM = memberViewModel.travelName ?? "제목 미정"
             }
         }
         .onDisappear {
             selectedTravel?.first?.name = travelNM
             mainVM.selectedTravel = self.selectedTravel?.first
+            viewModel.saveTravel()
         }
         .navigationTitle("새로운 여행 생성")
         .navigationBarBackButtonHidden(true)

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -102,9 +102,14 @@ struct PreviousTravelView: View {
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                     
-                                                    Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                        .font(.caption2)
-                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    if let endDate = previousTravel?[index].endDate {
+                                                        Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                            .font(.caption2)
+                                                            .foregroundStyle(Color.white.opacity(0.75))
+                                                    } else {
+                                                        Text("")
+                                                    }
+
                                                 }
                                                 .padding(.horizontal, 8)
                                                 .padding(.bottom, 8)
@@ -236,9 +241,13 @@ struct PreviousTravelView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(dateGapHandler.convertBeforeShowing(date: previousTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                                    .font(.caption2)
-                                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                                if let endDate = previousTravel?[index].endDate {
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                        .font(.caption2)
+                                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                                } else {
+                                                                    Text("")
+                                                                }
                                                             }
                                                             .padding(.horizontal, 8)
                                                             .padding(.bottom, 8)

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -18,7 +18,7 @@ struct TravelDetailView: View {
     @State var travelID: UUID = UUID()
     @State var travelName: String
     @State var startDate: Date
-    @State var endDate: Date
+    @State var endDate: Date?
     @State var dayCnt: Int
     @State var participantCnt: Int
     @State var participantArr: [String]
@@ -86,6 +86,7 @@ struct TravelDetailView: View {
                 viewModel.fetchTravel()
                 //                travelID = mainVM.selectedTravel?.id ?? UUID()
                 self.selectedTravel = viewModel.filterByID(selectedTravelID: travelID)
+                print("tttttt", endDate)
                 
             }
             .onDisappear {
@@ -134,7 +135,7 @@ struct TravelDetailView: View {
         VStack(alignment: .leading) {
             HStack {
                 
-                if Date() <= endDate {
+                if Date() <= endDate ?? Date.distantFuture {
                     HStack(alignment: .center, spacing: 10) {
                         Text("여행 중")
                             .font(
@@ -203,16 +204,23 @@ struct TravelDetailView: View {
     }
     
     private var dateBox: some View {
-        VStack {
+        VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 0) {
                     Text("시작일")
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
                         .padding(.bottom, 8)
-                    Text(dateGapHandler.convertBeforeShowing(date: startDate), formatter: TravelDetailViewModel.dateFormatter)
-                        .font(.body4)
-                        .foregroundStyle(Color.white)
+                    
+                    ZStack(alignment: .leading) {
+                        Text("00.00.00 (수)")
+                            .font(.body4)
+                            .hidden()
+                        
+                        Text(dateGapHandler.convertBeforeShowing(date: startDate), formatter: TravelDetailViewModel.dateFormatter)
+                            .font(.body4)
+                            .foregroundStyle(Color.white)
+                    }
                 }
                 
                 Spacer()
@@ -229,9 +237,22 @@ struct TravelDetailView: View {
                         .font(.subhead1)
                         .foregroundStyle(Color.white)
                         .padding(.bottom, 8)
-                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: TravelDetailViewModel.dateFormatter)
-                        .font(.body4)
-                        .foregroundStyle(Color.white)
+                    
+                    if let endDate = endDate {
+                        ZStack(alignment: .leading) {
+                            Text("00.00.00 (수)")
+                                .font(.body4)
+                                .hidden()
+                            
+                            Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: TravelDetailViewModel.dateFormatter)
+                                .font(.body4)
+                                .foregroundStyle(Color.white)
+                        }
+                    } else {
+                        Text("00.00.00 (수)")
+                            .font(.body4)
+                            .hidden()
+                    }
                 }
                 
                 Spacer()

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -114,13 +114,16 @@ struct TravelDetailView: View {
                     }
                 }
             }
-            .alert("Alert Title", isPresented: $isWarningOn) {
-                Button("Ok") {
+            .alert("여행 삭제하기", isPresented: $isWarningOn) {
+                Button("취소") {
+                    isWarningOn = false
+                }
+                Button("삭제하기") {
                     PersistenceController().deleteItems(object: self.selectedTravel?.first)
                     NavigationUtil.popToRootView()
                 }
             } message: {
-                Text("This is alert dialog sample")
+                Text("현재 선택한 여행방에 저장된 지출 기록 및 관련 데이터를 모두 삭제할까요?")
             }
         }
         .toolbar(.hidden, for: .tabBar)

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -84,9 +84,7 @@ struct TravelDetailView: View {
             )
             .onAppear {
                 viewModel.fetchTravel()
-                //                travelID = mainVM.selectedTravel?.id ?? UUID()
                 self.selectedTravel = viewModel.filterByID(selectedTravelID: travelID)
-                print("tttttt", endDate)
                 
             }
             .onDisappear {
@@ -274,7 +272,7 @@ struct TravelDetailView: View {
                 .font(.subhead1)
                 .foregroundStyle(Color.white)
             
-            if participantCnt <= 1 {
+            if participantCnt < 1 {
                 
                 HStack(alignment: .center, spacing: 4) {
                     Text("me")
@@ -291,7 +289,7 @@ struct TravelDetailView: View {
                 .background(Color(red: 0.2, green: 0.2, blue: 0.2))
                 .cornerRadius(6)
                 
-            } else if participantCnt <= 4 {
+            } else if participantCnt <= 3 {
                 
                 HStack {
                     HStack(alignment: .center, spacing: 4) {
@@ -309,9 +307,9 @@ struct TravelDetailView: View {
                     .background(Color(red: 0.2, green: 0.2, blue: 0.2))
                     .cornerRadius(6)
                     
-                    ForEach(2..<participantCnt, id: \.self) { index in
+                    ForEach(1..<participantCnt+1, id: \.self) { index in
                         HStack(alignment: .center, spacing: 10) {
-                            Text("\(participantArr[index])")
+                            Text("\(participantArr[index-1])")
                                 .font(.subhead2_2)
                                 .foregroundColor(.white)
                         }
@@ -334,16 +332,15 @@ struct TravelDetailView: View {
                     }
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    //                    .frame(height: 28, alignment: .center)
                     .background(Color(red: 0.2, green: 0.2, blue: 0.2))
                     .cornerRadius(6)
                     
                     HStack {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(alignment: .center, spacing: 10) {
-                            ForEach(1..<participantCnt, id: \.self) { index in
+                            ForEach(1..<participantCnt+1, id: \.self) { index in
                                 
-                                    Text("\(participantArr[index])")
+                                    Text("\(participantArr[index-1])")
                                         .font(.subhead2_2)
                                         .foregroundColor(.white)
                                 }

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -235,12 +235,18 @@ struct TravelListView: View {
                                                 
                                                 Spacer()
                                                 
-                                                HStack {
-                                                    Image(systemName: "person.fill")
-                                                        .frame(width: 12, height: 12)
-                                                        .foregroundStyle(Color.white)
+                                                HStack(spacing: 0) {
+                                                    HStack {
+                                                        Image(systemName: "person.fill")
+                                                            .frame(width: 12, height: 12)
+                                                            .foregroundStyle(Color.white)
+                                                        
+                                                        Text("me")
+                                                            .font(.caption2)
+                                                            .foregroundStyle(Color.white)
+                                                    }
                                                     
-                                                    Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? ["me"]))
+                                                    Text(viewModel.arrayToString(partArray: nowTravel?[index].participantArray ?? [""]))
                                                         .lineLimit(1)
                                                         .font(.caption2)
                                                         .foregroundStyle(Color.white)
@@ -248,6 +254,7 @@ struct TravelListView: View {
                                                 }
                                                 .padding(.leading, 50) // Doris : 참여자 뷰 제한을 위한 임의 수치
                                                 .padding(.trailing, 16)
+                                                
                                             }
                                             .frame(height: 16)
                                             

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -101,25 +101,30 @@ struct TravelListView: View {
     
     private var nowTravelingView: some View {
         ZStack(alignment: .center) {
-            if travelCount == 0 {
-                Rectangle()
-                    .foregroundColor(.clear)
-                    .frame(width: 350, height: 137)
-                    .background(
-                        ZStack {
-                            Color.gray100
-                            Text("현재 진행 중인 여행이 없어요")
-                                .font(.body2)
-                                .foregroundStyle(Color(0xA6A6A6))
-                        }
-                    )
-                    .cornerRadius(10)
-                    .padding(.bottom, 18)
+            if Int(nowTravel?.count ?? 0) == 0 {
+                ZStack {
+                    Rectangle()
+                        .foregroundColor(.clear)
+                        .frame(width: 350, height: 137)
+                        .background(
+                            ZStack {
+                                Color.gray100
+                                Text("현재 진행 중인 여행이 없어요")
+                                    .font(.body2)
+                                    .foregroundStyle(Color(0xA6A6A6))
+                            }
+                        )
+                        .cornerRadius(10)
+                        .padding(.bottom, 22)
+                }
+                .onAppear {
+                    print("rrrrr zero view shown")
+                }
             } else {
                 ZStack(alignment: .center) {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
-                            ForEach(0..<travelCount, id: \.self) { index in
+                            ForEach(0..<Int(nowTravel?.count ?? 0), id: \.self) { index in
                                 NavigationLink(destination: TravelDetailView(
                                     travelID: nowTravel?[index].id ?? UUID(),
                                     travelName: nowTravel?[index].name ?? "",

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -124,7 +124,7 @@ struct TravelListView: View {
                                     travelID: nowTravel?[index].id ?? UUID(),
                                     travelName: nowTravel?[index].name ?? "",
                                     startDate: nowTravel?[index].startDate ?? Date(),
-                                    endDate: nowTravel?[index].endDate ?? Date(),
+                                    endDate: nowTravel?[index].endDate,
                                     dayCnt: viewModel.differenceBetweenToday(today: Date(), startDate: nowTravel?[index].startDate ?? Date()),
                                     participantCnt: nowTravel?[index].participantArray?.count ?? 0,
                                     participantArr: nowTravel?[index].participantArray ?? [],
@@ -209,14 +209,24 @@ struct TravelListView: View {
                                                 .padding(.leading, 16)
                                             
                                             HStack {
-                                                Group {
-                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: TravelListViewModel.dateFormatter) +
-                                                    Text(" ~ ") +
-                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].endDate ?? Date()), formatter: TravelListViewModel.dateFormatter)
+                                                HStack(spacing: 0) {
+                                                    Text(dateGapHandler.convertBeforeShowing(date: nowTravel?[index].startDate ?? Date()), formatter: TravelListViewModel.dateFormatter)
+                                                        .font(.subhead2_2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                        .padding(.leading, 16)
+                                                    
+                                                    Text(" ~ ")
+                                                        .font(.subhead2_2)
+                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    
+                                                    if let endDate = nowTravel?[index].endDate {
+                                                        Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: TravelListViewModel.dateFormatter)
+                                                            .font(.subhead2_2)
+                                                            .foregroundStyle(Color.white.opacity(0.75))
+                                                    } else {
+                                                        Text("")
+                                                    }
                                                 }
-                                                .font(.subhead2_2)
-                                                .foregroundStyle(Color.white.opacity(0.75))
-                                                .padding(.leading, 16)
                                                 
                                                 Spacer()
                                                 

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -124,7 +124,7 @@ struct TravelListView: View {
                 ZStack(alignment: .center) {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
-                            ForEach(0..<Int(nowTravel?.count ?? 0), id: \.self) { index in
+                            ForEach(0..<Int(nowTravel?.count ?? 1), id: \.self) { index in
                                 NavigationLink(destination: TravelDetailView(
                                     travelID: nowTravel?[index].id ?? UUID(),
                                     travelName: nowTravel?[index].name ?? "",
@@ -258,43 +258,44 @@ struct TravelListView: View {
                                     }
                                     .onAppear {
                                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                                            
-                                            self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
-                                            if let savedExpenses = savedExpenses {
-                                                let countryValues: [Int64] = savedExpenses.map { expense in
-                                                    return viewModel.getCountryForExpense(expense)
+                                            if index > 0 {
+                                                self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
+                                                if let savedExpenses = savedExpenses {
+                                                    let countryValues: [Int64] = savedExpenses.map { expense in
+                                                        return viewModel.getCountryForExpense(expense)
+                                                    }
+                                                    let uniqueCountryValues = Array(Set(countryValues))
+                                                    
+                                                    var flagImageNames: [String] = []
+                                                    var defaultImage: [String] = []
+                                                    var koreanName: [String] = []
+                                                    
+                                                    for countryValue in uniqueCountryValues {
+                                                        
+                                                        if let flagString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.flagString {
+                                                            flagImageNames.append(flagString)
+                                                        } else {
+                                                            flagImageNames.append("DefaultFlag")
+                                                        }
+                                                        
+                                                        if let defaultString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.defaultImageString {
+                                                            defaultImage.append(defaultString)
+                                                        } else {
+                                                            defaultImage.append("DefaultImage")
+                                                        }
+                                                        
+                                                        if let koreanString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.koreanNm {
+                                                            koreanName.append(koreanString)
+                                                        } else {
+                                                            koreanName.append("")
+                                                        }
+                                                    }
+                                                    
+                                                    self.flagImageName = flagImageNames
+                                                    self.defaultImageName = defaultImage
+                                                    self.countryName = koreanName
+                                                    print("defaultImageName :", defaultImageName)
                                                 }
-                                                let uniqueCountryValues = Array(Set(countryValues))
-                                                
-                                                var flagImageNames: [String] = []
-                                                var defaultImage: [String] = []
-                                                var koreanName: [String] = []
-                                                
-                                                for countryValue in uniqueCountryValues {
-                                                    
-                                                    if let flagString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.flagString {
-                                                        flagImageNames.append(flagString)
-                                                    } else {
-                                                        flagImageNames.append("DefaultFlag")
-                                                    }
-                                                    
-                                                    if let defaultString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.defaultImageString {
-                                                        defaultImage.append(defaultString)
-                                                    } else {
-                                                        defaultImage.append("DefaultImage")
-                                                    }
-                                                    
-                                                    if let koreanString = CountryInfoModel.shared.countryResult[Int(countryValue)]?.koreanNm {
-                                                        koreanName.append(koreanString)
-                                                    } else {
-                                                        koreanName.append("")
-                                                    }
-                                                }
-                                                
-                                                self.flagImageName = flagImageNames
-                                                self.defaultImageName = defaultImage
-                                                self.countryName = koreanName
-                                                print("defaultImageName :", defaultImageName)
                                             }
                                         }
                                     }

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -243,8 +243,6 @@ struct TravelListView: View {
                                     }
                                     .onAppear {
                                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                                            viewModel.updateTravel()
-                                            viewModel.saveTravel()
                                             
                                             self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
                                             if let savedExpenses = savedExpenses {

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -103,9 +103,13 @@ struct UpcomingTravelView: View {
                                                     .font(.caption2)
                                                     .foregroundStyle(Color.white.opacity(0.75))
                                                     
-                                                    Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                        .font(.caption2)
-                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                    if let endDate = upcomingTravel?[index].endDate {
+                                                        Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                            .font(.caption2)
+                                                            .foregroundStyle(Color.white.opacity(0.75))
+                                                    } else {
+                                                        Text("")
+                                                    }
                                                 }
                                                 .padding(.horizontal, 8)
                                                 .padding(.bottom, 8)
@@ -237,9 +241,13 @@ struct UpcomingTravelView: View {
                                                                 .font(.caption2)
                                                                 .foregroundStyle(Color.white.opacity(0.75))
                                                                 
-                                                                Text(dateGapHandler.convertBeforeShowing(date: upcomingTravel?[index].endDate ?? Date()), formatter: PreviousTravelViewModel.dateFormatter)
-                                                                    .font(.caption2)
-                                                                    .foregroundStyle(Color.white.opacity(0.75))
+                                                                if let endDate = upcomingTravel?[index].endDate {
+                                                                    Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                                                                        .font(.caption2)
+                                                                        .foregroundStyle(Color.white.opacity(0.75))
+                                                                } else {
+                                                                    Text("")
+                                                                }
                                                             }
                                                             .padding(.horizontal, 8)
                                                             .padding(.bottom, 8)

--- a/UMM/ViewModel/CompleteAddTravelViewModel.swift
+++ b/UMM/ViewModel/CompleteAddTravelViewModel.swift
@@ -40,6 +40,15 @@ class CompleteAddTravelViewModel: ObservableObject {
         }
     }
     
+    func saveTravel() {
+        do {
+            try viewContext.save()
+            print("save travel")
+        } catch let error {
+            print("Error while SaveTravel: \(error.localizedDescription)")
+        }
+    }
+    
     func dateToString(in date: Date?) -> String {
         if date == nil {
             return ""

--- a/UMM/ViewModel/InterimRecordViewModel.swift
+++ b/UMM/ViewModel/InterimRecordViewModel.swift
@@ -141,7 +141,8 @@ class InterimRecordViewModel: ObservableObject {
     
     func filterTravelByDate(todayDate: Date) -> [Travel] {
         return nowTravel.filter { travel in
-            if let startDate = travel.startDate, let endDate = travel.endDate {
+            if let startDate = travel.startDate {
+                let endDate = travel.endDate ?? Date.distantFuture
                 print("filterTravelByDate | travel.id: \(String(describing: travel.id))")
                 return todayDate >= startDate && todayDate < endDate
             } else {

--- a/UMM/ViewModel/TravelListViewModel.swift
+++ b/UMM/ViewModel/TravelListViewModel.swift
@@ -83,11 +83,11 @@ class TravelListViewModel: ObservableObject {
     
     func filterTravelByDate(todayDate: Date) -> [Travel] {
         return nowTravel.filter { travel in
-            if let startDate = travel.startDate, let endDate = travel.endDate {
-                print("filterTravelByDate | travel.id: \(String(describing: travel.id))")
-                return todayDate >= startDate && todayDate < endDate
+            if let startDate = travel.startDate {
+                let endDate = travel.endDate ?? Date.distantFuture
+                return todayDate >= startDate && todayDate <= endDate
             } else {
-                print("filterTravelByDate | travel.id: nil")
+                print("filterTravelByDate | travel.startDate: nil")
                 return false
             }
         }

--- a/UMM/ViewModel/TravelListViewModel.swift
+++ b/UMM/ViewModel/TravelListViewModel.swift
@@ -97,6 +97,9 @@ class TravelListViewModel: ObservableObject {
         
         var res = ""
         for index in 0..<partArray.count {
+            if index == 0 {
+                res += ", "
+            }
             res += partArray[index]
             if index < partArray.count - 1 {
                 res += ", "


### PR DESCRIPTION
## 👀 이슈
- #216 
- #222 

## 💡 작업 내용
-  Travel 관련 뷰들의 수정사항을 반영합니다.
- 여행 참여자 관련 코드를 수정합니다

## 📱스크린샷

![Simulator Screen Recording - iPhone 15 - 2023-11-09 at 12 53 29](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/e780cde7-ff67-46d4-bd30-0f77c01e7b6d)

## 🚨 참고 사항

endDate를 다음과 같이 처리해주었을 때 인식을 못하는 오류가 있어서 임시로 주석처리하고 local235959() 처리를 하지 않았습니다.
```swift
 if let endDate = viewModel.endDate {
                    viewModel.endDate = endDate.local235959().convertBeforeSaving()
               } else {
                    viewModel.endDate = nil
               }
```

## (Optional) 🤔 고민한 점
nowTravelingView에서 nowTravel의 개수가 0개여도 nowTravel이 0이 아닐 때 뷰의 onAppear가 실행되면서  nowTravel?[index].id  해당 코드에서 오류가 발생했었는데 , 해당 코드를 조건문안에 넣어서 해결했습니다. 

```swift
 if index > 0 {
       self.savedExpenses = viewModel.filterExpensesByTravel(selectedTravelID: nowTravel?[index].id ?? UUID())
}
```