### PR TITLE
:bug:[#259] 위치 정보 허용 창 안 떠서 앱이 멈춰보이는 문제 해결

### DIFF
--- a/UMM/Handler/DateGapHandler.swift
+++ b/UMM/Handler/DateGapHandler.swift
@@ -20,7 +20,10 @@ final class DateGapHandler {
     static let shared = DateGapHandler()
     let calendar = Calendar.current
     
-    private init() {
+    private init() {}
+    
+    func getTimeDifference() {
+        
         getLocation()
         let baseCoordinate = CLLocationCoordinate2D(latitude: 37.56, longitude: 127.00) // 서울 (latitude: 37.56, longitude: 127.00)
         // CLGeocoder를 사용하여 위치 정보를 가져온다.
@@ -52,7 +55,7 @@ final class DateGapHandler {
     private var locationManager: CLLocationManager?
     private var locationManagerDelegate = LocationManagerDelegateForDateGapHandler()
     var currentLocation: CLLocation?
-    var timeDifferenceInterval: TimeInterval = 0
+    private var timeDifferenceInterval: TimeInterval = 0
     
     private func getLocation() {
         let locationManager = CLLocationManager()

--- a/UMM/View/MainView.swift
+++ b/UMM/View/MainView.swift
@@ -66,6 +66,9 @@ struct MainView: View {
             if loadedData == nil || !exchangeRateHandler.isSameDate(loadedData?.time_last_update_unix) {
                 exchangeRateHandler.fetchAndSaveExchangeRates()
             }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                DateGapHandler.shared.getTimeDifference()
+            }
         }
         .accentColor(Color.mainPink)
         .environmentObject(viewModel)


### PR DESCRIPTION
## 👀 이슈
- #259

## 💡 작업 내용
- 앱 삭제하고 새로 설치하고 처음 실행할 때 위치 정보를 묻는 창이 보이지 않아 앱이 멈춰보이는 문제를 해결했습니다.
- 기존에는 앱을 inactive 상태로 만들어서 묻는 창을 보아야 했습니다.

## 📱스크린샷
-

## 🚨 참고 사항
-

## 🤔 고민한 점
- 위치 정보를 처음 사용하는 함수를 MainView의 onAppear에서 호출해도 해결되지 않아서, onAppear에서도 1초 미뤄서 실행했습니다.
