### PR TITLE
:bug:[#267] ManualRecordInExpenseView에서 participantArray가 정상 작동하도록 수정

### DIFF
--- a/UMM/Handler/DateGapHandler.swift
+++ b/UMM/Handler/DateGapHandler.swift
@@ -38,8 +38,8 @@ final class DateGapHandler {
     
     private init() {
         timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
-            print("DateGapHandler | location: \(self.currentLocation?.description ?? "nil")")
-            print("DateGapHandler | timeDifference: \(self.timeDifferenceInterval.description)")
+//            print("DateGapHandler | location: \(self.currentLocation?.description ?? "nil")")
+//            print("DateGapHandler | timeDifference: \(self.timeDifferenceInterval.description)")
         }
     }
     

--- a/UMM/View/Record/ManualRecordInExpenseView.swift
+++ b/UMM/View/Record/ManualRecordInExpenseView.swift
@@ -137,11 +137,15 @@ struct ManualRecordInExpenseView: View {
             }
 
             if let participantArray = MainViewModel.shared.chosenTravelInManualRecord?.participantArray {
-                viewModel.participantTupleArray = [("나", true)] + participantArray.map { ($0, true) }
+                viewModel.participantTupleArray = participantArray.map { participant in
+                    let isSelected = given_expense.participantArray?.contains(participant) ?? false
+                    return (name: participant, isOn: isSelected)
+                }
             } else {
-                viewModel.participantTupleArray = [("나", true)]
+                print("ManualRecordInExpenseView | else")
+                viewModel.participantTupleArray = [(name: "나", isOn: true)]
             }
-            
+
             // 초기값
             MainViewModel.shared.chosenTravelInManualRecord = given_expense.travel
             

--- a/UMM/ViewModel/ManualRecordViewModel.swift
+++ b/UMM/ViewModel/ManualRecordViewModel.swift
@@ -296,6 +296,7 @@ final class ManualRecordViewModel: NSObject, ObservableObject {
         expense.info = info
         expense.location = locationExpression
         expense.participantArray = participantTupleArray.filter { $0.1 == true }.map { $0.0 }
+        print("ManualRecordView | expense.participantArray: \(String(describing: expense.participantArray))")
         expense.payAmount = payAmount
         expense.payDate = DateGapHandler.shared.convertBeforeSaving(date: payDate)
         expense.paymentMethod = Int64(paymentMethod.rawValue)


### PR DESCRIPTION
## 👀 이슈
- #267 

## 💡 작업 내용
- ManualRecordInExpenseView에서 participantArray가 정상 작동하도록 수정

## 📱스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-11-13 at 22 09 14](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/102353544/ccce652e-c4a2-4ce1-9c12-daee41f54a81)

## 🚨 참고사항
```
    private init() {
        timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
//            print("DateGapHandler | location: \(self.currentLocation?.description ?? "nil")")
//            print("DateGapHandler | timeDifference: \(self.timeDifferenceInterval.description)")
        }
    }
```
DateGapHandler에서 3초마다 print 하는 부분을 주석 처리하였습니다.
필요한 부분이라면 되살려서 commit 하도록 하겠습니다. 
@oliver-or-not 확인 부탁해요 ~

## (Optional) 🤔 고민한 점
```
// ManualRecordInExpenseView.swift

if let participantArray = MainViewModel.shared.chosenTravelInManualRecord?.participantArray {
    viewModel.participantTupleArray = participantArray.map { participant in
        let isSelected = given_expense.participantArray?.contains(participant) ?? false
        return (name: participant, isOn: isSelected)
    }
} else {
    viewModel.participantTupleArray = [(name: "나", isOn: true)]
}
```

```
// ManualRecordInExpenseViewModel.swift

if let participantArrayInChosenTravel = chosenTravel.participantArray {
    var updatedParticipantArray = participantArrayInChosenTravel
    updatedParticipantArray.insert("나", at: 0)
    self.participantTupleArray = updatedParticipantArray.map { participant in
        let isSelected = expense.participantArray?.contains(participant) ?? false
        return (name: participant, isOn: isSelected)
    }
} else {
    self.participantTupleArray = [("나", true)]
}
```

- View에서는 MainViewModel에 저장된 participant 배열에서, 선택된 expense에 저장된 participant만 true인 형태로 보여주도록 수정했습니다.
- ViewModel에서는 participantArray에 "나"를 저장하고 있지 않기 때문에, 임의로 넣어준 뒤에 View와 비슷한 로직을 구현했습니다.