### PR TITLE
🎨⚡️[#307][#308] (Travel 관련) 버전 1.1.1이후 수정사항들을 반영합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -845,7 +845,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UMM/Preview Content\"";
-				DEVELOPMENT_TEAM = 8H4K6TKQBU;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -865,7 +865,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.UMM.nomadwallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -885,7 +885,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UMM/Preview Content\"";
-				DEVELOPMENT_TEAM = 8H4K6TKQBU;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -905,7 +905,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.UMM.nomadwallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -270,7 +270,7 @@ struct AddMemberView: View {
         HStack {
             Spacer()
             
-            if isSelectedTogether == true && participantArr.count == 0 {
+            if isSelectedTogether == true && participantArr.count == 1 && participantArr[0] == "" {
                 DoneButtonUnactive(title: "완료", action: {
                     
                 })
@@ -291,7 +291,6 @@ struct AddMemberView: View {
                             viewModel.travelName = "\(participantArr[0])님과의 여행"
                             viewModel.participantArr = participantArr
                         } else if participantArr.count == 0 && self.isSelectedAlone == true {
-//                            let updateArr = Array(participantArr.dropLast())
                             viewModel.participantArr = participantArr
                             viewModel.travelName = "나의 여행"
                         } else if participantArr.count == 0 {

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -16,11 +16,8 @@ struct AddMemberView: View {
     @ObservedObject private var viewModel = AddMemberViewModel()
     @ObservedObject var addViewModel: AddTravelViewModel
     
-    @State var participantArr: [String] {
-        didSet {
-            print("participantArr.count: \(participantArr.count)")
-        }
-    }
+    @State var participantArr: [String]
+    
     @State var travelName: String?
     @State var travelID = UUID()
     @Binding var startDate: Date?
@@ -284,9 +281,13 @@ struct AddMemberView: View {
                         viewModel.startDate = startDate?.local000().convertBeforeSaving()
                         viewModel.endDate = endDate?.local235959().convertBeforeSaving()
                         
-                        // 여행 이름
+                        // 1. 빈칸 제거
                         participantArr = viewModel.filterEmptyStrings(participantArr)
-                    
+                        // 2. '나' 제거
+                        participantArr = viewModel.filterMeFromStrings(participantArr)
+                        // 3. 중복 제거
+                        participantArr = viewModel.filterDuplicates(participantArr)
+                        
                         if participantArr.count == 1 && self.isSelectedTogether == true {
                             viewModel.travelName = "\(participantArr[0])님과의 여행"
                             viewModel.participantArr = participantArr

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -295,7 +295,7 @@ struct AddMemberView: View {
                             viewModel.participantArr = participantArr
                             viewModel.travelName = "나의 여행"
                         } else if participantArr.count == 0 {
-                            viewModel.travelName = "나의 여행l"
+                            viewModel.travelName = "나의 여행"
                             viewModel.participantArr = participantArr
                         } else {
                             viewModel.travelName = "\(participantArr[0]) 외 \(participantArr.count)명의 여행"

--- a/UMM/View/Travel/AddMemberView.swift
+++ b/UMM/View/Travel/AddMemberView.swift
@@ -285,13 +285,18 @@ struct AddMemberView: View {
                         viewModel.endDate = endDate?.local235959().convertBeforeSaving()
                         
                         // 여행 이름
+                        participantArr = viewModel.filterEmptyStrings(participantArr)
+                    
                         if participantArr.count == 1 && self.isSelectedTogether == true {
                             viewModel.travelName = "\(participantArr[0])님과의 여행"
                             viewModel.participantArr = participantArr
-                        } else if participantArr.count == 1 && self.isSelectedAlone == true {
-                            let updateArr = Array(participantArr.dropLast())
-                            viewModel.participantArr = updateArr
+                        } else if participantArr.count == 0 && self.isSelectedAlone == true {
+//                            let updateArr = Array(participantArr.dropLast())
+                            viewModel.participantArr = participantArr
                             viewModel.travelName = "나의 여행"
+                        } else if participantArr.count == 0 {
+                            viewModel.travelName = "나의 여행l"
+                            viewModel.participantArr = participantArr
                         } else {
                             viewModel.travelName = "\(participantArr[0]) 외 \(participantArr.count)명의 여행"
                             viewModel.participantArr = participantArr

--- a/UMM/View/Travel/CompleteAddTravelView.swift
+++ b/UMM/View/Travel/CompleteAddTravelView.swift
@@ -98,7 +98,7 @@ struct CompleteAddTravelView: View {
                             if let endDate = selectedTravel?.first?.endDate {
                                 Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
                             } else {
-                                Text("")
+                                Text("미정")
                             }
                         }
                         .font(.custom(FontsManager.Pretendard.medium, size: 20))

--- a/UMM/View/Travel/CompleteAddTravelView.swift
+++ b/UMM/View/Travel/CompleteAddTravelView.swift
@@ -19,6 +19,8 @@ struct CompleteAddTravelView: View {
     @State var participantArr: [String]
     @State var selectedTravel: [Travel]?
     
+    let dateGapHandler = DateGapHandler.shared
+    
     var body: some View {
         VStack(spacing: 0) {
             
@@ -61,7 +63,7 @@ struct CompleteAddTravelView: View {
             self.selectedTravel = viewModel.filterTravelByID(selectedTravelID: travelID)
             self.travelNM = memberViewModel.travelName ?? "제목 미정"
             self.participantArr = memberViewModel.participantArr ?? ["me"]
-        }  
+        }
         .onAppear(perform: UIApplication.shared.hideKeyboard)
         .navigationTitle("새로운 여행 생성")
         .navigationBarBackButtonHidden(true)
@@ -91,10 +93,13 @@ struct CompleteAddTravelView: View {
                     HStack {
                         VStack(alignment: .leading) {
                             
-                            Text(viewModel.dateToString(in: selectedTravel?.first?.startDate) + " ~")
+                            Text(viewModel.dateToString(in: dateGapHandler.convertBeforeShowing(date: selectedTravel?.first?.startDate ?? Date())) + " ~")
                             
-                            Text(viewModel.endDateToString(in: selectedTravel?.first?.endDate))
-                            
+                            if let endDate = selectedTravel?.first?.endDate {
+                                Text(dateGapHandler.convertBeforeShowing(date: endDate), formatter: PreviousTravelViewModel.dateFormatter)
+                            } else {
+                                Text("")
+                            }
                         }
                         .font(.custom(FontsManager.Pretendard.medium, size: 20))
                         .padding(.top, 90)

--- a/UMM/View/Travel/TravelButtonView.swift
+++ b/UMM/View/Travel/TravelButtonView.swift
@@ -27,7 +27,6 @@ struct TravelButtonView: View {
 //    private func onTravelSelected() {
 //        isSelected.toggle()
 //        
-//        // 여행이 선택되었을 때 추가로 수행해야 할 로직이 있다면 여기에 추가
 //        viewModel.chosenTravel = isSelected ? travel : nil
 //        if chosenTravel == travel {
 //            chosenTravel = nil

--- a/UMM/View/Travel/TravelButtonView.swift
+++ b/UMM/View/Travel/TravelButtonView.swift
@@ -46,6 +46,7 @@ struct TravelButtonView: View {
                 }
                 isSelectedTravel = (chosenTravel != nil)
                 viewModel.chosenTravel = chosenTravel
+                print("iiii \(viewModel.chosenTravel)")
             } label: {
                 ZStack {
                     if let imageString = {
@@ -74,7 +75,7 @@ struct TravelButtonView: View {
                             Button {
                                 
                             } label: {
-                                if chosenTravel != travel {
+                                if viewModel.chosenTravel != travel {
                                     Circle()
                                         .fill(.black)
                                         .opacity(0.25)
@@ -148,7 +149,7 @@ struct TravelButtonView: View {
                     RoundedRectangle(cornerRadius: 10)
                         .frame(width: 110, height: 80)
                         .foregroundStyle(.gray100)
-                        .opacity(chosenTravel == travel ? 0.0 : 0.4)
+                        .opacity(viewModel.chosenTravel == travel ? 0.0 : 0.4)
                 }
                 .frame(width: 110, height: 80)
                 .onAppear {

--- a/UMM/View/Travel/TravelButtonView.swift
+++ b/UMM/View/Travel/TravelButtonView.swift
@@ -23,11 +23,29 @@ struct TravelButtonView: View {
     
     let dateGapHandler = DateGapHandler.shared
     
+//    @State private var isSelected: Bool = false
+//    private func onTravelSelected() {
+//        isSelected.toggle()
+//        
+//        // 여행이 선택되었을 때 추가로 수행해야 할 로직이 있다면 여기에 추가
+//        viewModel.chosenTravel = isSelected ? travel : nil
+//        if chosenTravel == travel {
+//            chosenTravel = nil
+//        } else {
+//            chosenTravel = travel
+//        }
+//        isSelectedTravel = (chosenTravel != nil)
+//    }
+    
     var body: some View {
         VStack {
             Button {
-                chosenTravel = travel
-                isSelectedTravel = true
+                if chosenTravel == travel {
+                    chosenTravel = nil
+                } else {
+                    chosenTravel = travel
+                }
+                isSelectedTravel = (chosenTravel != nil)
                 viewModel.chosenTravel = chosenTravel
             } label: {
                 ZStack {
@@ -55,7 +73,7 @@ struct TravelButtonView: View {
                     VStack(alignment: .leading) {
                         HStack {
                             Button {
-                                chosenTravel = travel
+                                
                             } label: {
                                 if chosenTravel != travel {
                                     Circle()
@@ -176,6 +194,11 @@ struct TravelButtonView: View {
                 .font(.subhead1)
                 .lineLimit(1)
         }
+//        .onChange(of: chosenTravel) { _, newChosenTravel in
+//            if newChosenTravel != travel {
+//                chosenTravel = nil
+//            }
+//        }
     }
 }
 

--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -171,27 +171,39 @@ struct TravelDetailView: View {
                 .font(.subhead1)
                 .foregroundStyle(Color.white)
             
-            HStack {
-                
-                ForEach(0..<koreanNM.count, id: \.self) { index in
+            if koreanNM.count > 0 {
+                HStack {
                     
-                    HStack {
-                        Image(flagImageArr[index])
-                            .resizable()
-                            .frame(width: 24, height: 24)
+                    ForEach(0..<koreanNM.count, id: \.self) { index in
                         
-                        Text(koreanNM[index])
-                            .font(.body2)
-                            .foregroundStyle(Color.white)
+                        HStack {
+                            Image(flagImageArr[index])
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                            
+                            Text(koreanNM[index])
+                                .font(.body2)
+                                .foregroundStyle(Color.white)
+                        }
+                        
+                        .padding(.trailing, 18)
+                        
                     }
                     
-                    .padding(.trailing, 18)
-                    
+                    Spacer()
                 }
-                
-                Spacer()
+                .padding(.vertical, 20)
+            } else {
+                HStack {
+                    Text("지출 기록 시 자동으로 국가가 등록됩니다.")
+                        .font(.body2)
+                        .foregroundStyle(Color.white)
+                        .frame(height: 24)
+                    
+                    Spacer()
+                }
+                .padding(.vertical, 20)
             }
-            .padding(.vertical, 20)
             
             Rectangle()
                 .foregroundColor(.clear)

--- a/UMM/ViewModel/AddMemberViewModel.swift
+++ b/UMM/ViewModel/AddMemberViewModel.swift
@@ -53,4 +53,8 @@ class AddMemberViewModel: ObservableObject {
         
         MainViewModel.shared.selectedTravel = newTravel
     }
+    
+    func filterEmptyStrings(_ array: [String]) -> [String] {
+        return array.filter { !$0.isEmpty }
+    }
 }

--- a/UMM/ViewModel/AddMemberViewModel.swift
+++ b/UMM/ViewModel/AddMemberViewModel.swift
@@ -57,4 +57,12 @@ class AddMemberViewModel: ObservableObject {
     func filterEmptyStrings(_ array: [String]) -> [String] {
         return array.filter { !$0.isEmpty }
     }
+    
+    func filterMeFromStrings(_ array: [String]) -> [String] {
+        return array.filter { $0 != "나" }
+    }
+    
+    func filterDuplicates(_ array: [String]) -> [String] {
+        return Array(Set(array))
+    }
 }

--- a/UMM/ViewModel/InterimRecordViewModel.swift
+++ b/UMM/ViewModel/InterimRecordViewModel.swift
@@ -117,7 +117,7 @@ class InterimRecordViewModel: ObservableObject {
     // MARK: 각각의 여행들이 몇갠지 찾기위한 함수들
     func filterPreviousTravel(todayDate: Date) -> [Travel] {
         return previousTravel.filter { travel in
-            if let endDate = travel.endDate {
+            if let endDate = travel.endDate?.convertBeforeShowing() {
                 print("filterPreviousTravel | travel.id \(String(describing: travel.id))")
                 return endDate < todayDate
             } else {
@@ -129,7 +129,7 @@ class InterimRecordViewModel: ObservableObject {
     
     func filterUpcomingTravel(todayDate: Date) -> [Travel] {
         return upcomingTravel.filter { travel in
-            if let startDate = travel.startDate {
+            if let startDate = travel.startDate?.convertBeforeShowing() {
                 print("filterUpcomingTravel travel.id \(String(describing: travel.id))")
                 return startDate > todayDate
             } else {
@@ -141,8 +141,8 @@ class InterimRecordViewModel: ObservableObject {
     
     func filterTravelByDate(todayDate: Date) -> [Travel] {
         return nowTravel.filter { travel in
-            if let startDate = travel.startDate {
-                let endDate = travel.endDate ?? Date.distantFuture
+            if let startDate = travel.startDate?.convertBeforeShowing() {
+                let endDate = travel.endDate?.convertBeforeShowing() ?? Date.distantFuture
                 print("filterTravelByDate | travel.id: \(String(describing: travel.id))")
                 return todayDate >= startDate && todayDate < endDate
             } else {

--- a/UMM/ViewModel/PreviousTravelViewModel.swift
+++ b/UMM/ViewModel/PreviousTravelViewModel.swift
@@ -52,7 +52,7 @@ class PreviousTravelViewModel: ObservableObject {
     
     func filterPreviousTravel(todayDate: Date) -> [Travel] {
         return previousTravel.filter { travel in
-            if let endDate = travel.endDate {
+            if let endDate = travel.endDate?.convertBeforeShowing() {
                 print("filterPreviousTravel | travel.id \(String(describing: travel.id))")
                 return endDate < todayDate
             } else {

--- a/UMM/ViewModel/TravelListViewModel.swift
+++ b/UMM/ViewModel/TravelListViewModel.swift
@@ -83,8 +83,8 @@ class TravelListViewModel: ObservableObject {
     
     func filterTravelByDate(todayDate: Date) -> [Travel] {
         return nowTravel.filter { travel in
-            if let startDate = travel.startDate {
-                let endDate = travel.endDate ?? Date.distantFuture
+            if let startDate = travel.startDate?.convertBeforeShowing() {
+                let endDate = travel.endDate?.convertBeforeShowing() ?? Date.distantFuture
                 return todayDate >= startDate && todayDate <= endDate
             } else {
                 print("filterTravelByDate | travel.startDate: nil")

--- a/UMM/ViewModel/UpcomingTravelViewModel.swift
+++ b/UMM/ViewModel/UpcomingTravelViewModel.swift
@@ -52,7 +52,7 @@ class UpcomingTravelViewModel: ObservableObject {
     
     func filterUpcomingTravel(todayDate: Date) -> [Travel] {
         return upcomingTravel.filter { travel in
-            if let startDate = travel.startDate {
+            if let startDate = travel.startDate?.convertBeforeShowing() {
                 print("filterUpcomingTravel travel.id \(String(describing: travel.id))")
                 return startDate > todayDate
             } else {


### PR DESCRIPTION
## 👀 이슈
- #307 
- #308 

## 💡 작업 내용
- TravelDetailView에서 아직 지출기록이 없을 경우 문구 추가 (임의로 내가 정한 문구)
- TravelButtonView에서 두 번 클릭 시 선택 해제
- TravelButonView에서 나라가 하나만 선택되도록 수정
- AddMemberView에서 빼먹은 dateGapHandler 적용
- AddMemberViewModel에서 함수를 정의해 **중복 / 빈 문자열 / 나** 제거
- @oliver-or-not 가 찾은 여행 filter시 convertBeforeShowing() 처리

## 📱스크린샷

- 임시기록
![Simulator Screen Recording - iPhone 15 - 2023-11-19 at 23 41 24](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/69ebb7f8-55a1-4b59-827e-d2d669bca9b5)

- 여행 생성
![Simulator Screen Recording - iPhone 15 - 2023-11-19 at 23 42 57](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/df8fadad-c962-4fa7-8723-bc08b81c1e78)

## 🚨 참고 사항

여행 참여자를 추가하는 플로우에서 혹시 빼먹은 케이스가 있는지 확인 부탁드려요..🥹
```swift
if participantArr.count == 1 && self.isSelectedTogether == true {
                            viewModel.travelName = "\(participantArr[0])님과의 여행"
                            viewModel.participantArr = participantArr
                        } else if participantArr.count == 0 && self.isSelectedAlone == true {
                            viewModel.participantArr = participantArr
                            viewModel.travelName = "나의 여행"
                        } else if participantArr.count == 0 {
                            viewModel.travelName = "나의 여행"
                            viewModel.participantArr = participantArr
                        } else {
                            viewModel.travelName = "\(participantArr[0]) 외 \(participantArr.count)명의 여행"
                            viewModel.participantArr = participantArr
                        }
```
## (Optional) 🤔 고민한 점

1. 정산자가 여러 명일 경우에 이름을 하나도 입력하지 않고 넘어갔을 때 뷰가 멈추는 오류가 있었는데, `participantArr[0] == "" `다음 조건을 추가해 참여자가 1명이고 participantArr의 첫번째 칸이 비어있을 경우에는 완료버튼이 넘어가지 않도록 하였습니다.
2. participantArr의 필터 함수들은 didSet 대신 모두 AddMemberViewModel에 구현하였습니다.
