### PR TITLE
🔨[#311] 최초 임시기록 시 UI가 깨지는 오류를 해결합니다.

### DIFF
--- a/UMM/View/Travel/TravelDetailView.swift
+++ b/UMM/View/Travel/TravelDetailView.swift
@@ -195,9 +195,9 @@ struct TravelDetailView: View {
                 .padding(.vertical, 20)
             } else {
                 HStack {
-                    Text("지출 기록 시 자동으로 국가가 등록됩니다.")
+                    Text("소비 기록을 남기면 자동으로 채워져요.")
                         .font(.body2)
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(Color.gray200)
                         .frame(height: 24)
                     
                     Spacer()

--- a/UMM/View/Travel/TravelListView.swift
+++ b/UMM/View/Travel/TravelListView.swift
@@ -28,7 +28,9 @@ struct TravelListView: View {
     @State private var flagImageName: [String] = []
     @State private var defaultImageName: [String] = []
     @State private var countryName: [String] = []
-
+    
+    @State private var travelTabViewRedrawer = true
+    
     let dateGapHandler = DateGapHandler.shared
     let handler = ExchangeRateHandler.shared
     
@@ -64,7 +66,12 @@ struct TravelListView: View {
                     .padding(.top, 12)
                     .offset(y: -18)
                     
-                TravelTabView()
+                if travelTabViewRedrawer {
+                    TravelTabView()
+                } else {
+                    EmptyView()
+                }
+                
             }
             .ignoresSafeArea(edges: .bottom)
             .onAppear {
@@ -79,6 +86,10 @@ struct TravelListView: View {
                 let loadedData = handler.loadExchangeRatesFromUserDefaults()
                 if loadedData == nil || !handler.isSameDate(loadedData?.time_last_update_unix) {
                     handler.fetchAndSaveExchangeRates()
+                }
+                travelTabViewRedrawer = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    travelTabViewRedrawer = true
                 }
             }
             .toolbar {

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -79,7 +79,7 @@ struct UpcomingTravelView: View {
             DispatchQueue.main.async {
                 viewModel.fetchTravel()
                 viewModel.fetchExpense()
-                self.upcomingTravel = viewModel.filterUpcomingTravel(todayDate: Date())
+                self.upcomingTravel = viewModel.filterUpcomingTravel(todayDate: Date()).filter { $0.name != tempTravelName }
             }
         }
     }


### PR DESCRIPTION
## 👀 이슈
- #311 

## 💡 작업 내용
- 최초 임시기록 시 UI가 깨지는 오류를 해결
- TravelListView가 onAppear될 때 TravelTabView를 항상 다시 그릴 수 있도록 함

## 📱스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-11-20 at 16 18 26](https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/63e87e3f-38bb-4f29-90c3-21ebbdee8fa6)

## 🚨 참고 사항


## (Optional) 🤔 고민한 점
- TabView안에 있는 것들만 위치를 찾지 못하는 이유를 모르겠음

```swift
struct TravelTabView: View {
    
    @State private var currentTab: Int = 0
    
    var body: some View {
        ZStack(alignment: .top) {
            TabView(selection: self.$currentTab) {
                PreviousTravelView()
                    .gesture(DragGesture().onChanged { _ in
                        // PreviousTravelView에서 DragGesture가 시작될 때의 동작
                    })
                    .tag(0)
                
                UpcomingTravelView()
                    .gesture(DragGesture().onChanged { _ in
                        // PreviousTravelView에서 DragGesture가 시작될 때의 동작
                    })
                    .tag(1)
            }
            .padding(.top, 12)
            .tabViewStyle(.page(indexDisplayMode: .never))
            
            Divider()
                .frame(height: 1)
                .padding(.top, 36)
            
            TabBarView(currentTab: self.$currentTab)
        }
    }
}
```