### PR TITLE
🎨[#335] TravelListView의 화면을 SE 화면비율을 고려합니다.

### DIFF
--- a/UMM.xcodeproj/project.pbxproj
+++ b/UMM.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		C18168042AFDE08700130F79 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18168032AFDE08700130F79 /* LottieView.swift */; };
 		C190C2032ADAAE2C0099EE3A /* AddMemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190C2022ADAAE2C0099EE3A /* AddMemberView.swift */; };
 		C190C20C2ADCD47E0099EE3A /* ButtonTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190C20B2ADCD47E0099EE3A /* ButtonTheme.swift */; };
+		C192C41E2B0F40A700842C89 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C192C41D2B0F40A700842C89 /* Constants.swift */; };
 		C19ACF7C2AEA341400D950C9 /* TravelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19ACF7B2AEA341400D950C9 /* TravelDetailView.swift */; };
 		C19AFADF2ADEAEC80037A5F5 /* CompleteAddTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFADE2ADEAEC70037A5F5 /* CompleteAddTravelView.swift */; };
 		C19AFAE12ADF709E0037A5F5 /* AddMemberViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFAE02ADF709E0037A5F5 /* AddMemberViewModel.swift */; };
@@ -177,6 +178,7 @@
 		C18168032AFDE08700130F79 /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		C190C2022ADAAE2C0099EE3A /* AddMemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemberView.swift; sourceTree = "<group>"; };
 		C190C20B2ADCD47E0099EE3A /* ButtonTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTheme.swift; sourceTree = "<group>"; };
+		C192C41D2B0F40A700842C89 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C19ACF7B2AEA341400D950C9 /* TravelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDetailView.swift; sourceTree = "<group>"; };
 		C19AFADE2ADEAEC70037A5F5 /* CompleteAddTravelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteAddTravelView.swift; sourceTree = "<group>"; };
 		C19AFAE02ADF709E0037A5F5 /* AddMemberViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemberViewModel.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 			isa = PBXGroup;
 			children = (
 				C19AFAE92AE00A920037A5F5 /* NavigationUtils.swift */,
+				C192C41D2B0F40A700842C89 /* Constants.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -660,6 +663,7 @@
 				C18168022AFDE07000130F79 /* SplashView.swift in Sources */,
 				E2D4247E2AEF580E00A9ADC9 /* ExchangeRateHandler.swift in Sources */,
 				C17550542AD54FC900A61BE5 /* AddTravelView.swift in Sources */,
+				C192C41E2B0F40A700842C89 /* Constants.swift in Sources */,
 				C19AFAF02AE116FF0037A5F5 /* PreviousTravelView.swift in Sources */,
 				572BE1E82AE49FB5005933E7 /* Redrawer.swift in Sources */,
 				C190C2032ADAAE2C0099EE3A /* AddMemberView.swift in Sources */,

--- a/UMM/Utils/Constants.swift
+++ b/UMM/Utils/Constants.swift
@@ -1,0 +1,56 @@
+//
+//  Constants.swift
+//  UMM
+//
+//  Created by GYURI PARK on 2023/11/23.
+//
+
+import Foundation
+import SwiftUI
+
+struct Constants {
+    static var travelCnt: Int {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 375, height: 667):  // SE
+            return 3
+        default:
+            return 6
+        }
+    }
+    
+    static var indicatorOffset: CGFloat {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 375, height: 667):
+            return 55
+        default:
+            return 125
+        }
+    }
+    
+    static var interimOffset: CGFloat {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 375, height: 667):
+            return 55
+        default:
+            return 95
+        }
+    }
+    
+    static var frameWidth: CGFloat? {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 375, height: 667):
+            return 100
+        default:
+            return 110
+        }
+    }
+    
+    static var frameHeight: CGFloat? {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 375, height: 667):
+            return 70
+        default:
+            return 80
+        }
+    }
+}

--- a/UMM/View/Record/InterimOncomingView.swift
+++ b/UMM/View/Record/InterimOncomingView.swift
@@ -31,7 +31,7 @@ struct InterimOncomingView: View {
                     .font(.custom(FontsManager.Pretendard.medium, size: 16))
                     .foregroundStyle(Color(0xA6A6A6))
                 
-            } else if onComingCnt <= 6 {
+            } else if onComingCnt <= Constants.travelCnt {
                 VStack {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0..<onComingCnt, id: \.self) { index in
@@ -46,10 +46,10 @@ struct InterimOncomingView: View {
                 ZStack {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
-                            ForEach(0 ..< (onComingCnt+5)/6, id: \.self) { page in
+                            ForEach(0 ..< (onComingCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { page in
                                 VStack {
                                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                        ForEach((page * 6) ..< min((page+1) * 6, onComingCnt), id: \.self) { index in
+                                        ForEach((page * Constants.travelCnt) ..< min((page+1) * Constants.travelCnt, onComingCnt), id: \.self) { index in
                                             TravelButtonView(viewModel: viewModel, travel: onComingTravel?[index] ?? Travel(), travelCnt: onComingCnt, isSelectedTravel: $isSelectedTravel)
                                         }
                                     }
@@ -63,13 +63,13 @@ struct InterimOncomingView: View {
                     }
                     
                     HStack(spacing: 6) {
-                        ForEach(0..<(onComingCnt+5)/6, id: \.self) { index in
+                        ForEach(0..<(onComingCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { index in
                             Capsule()
                                 .fill(currentPage == index ? Color.black : Color.gray200)
                                 .frame(width: 5, height: 5)
                         }
                     }
-                    .offset(y: 95)
+                    .offset(y: Constants.interimOffset)
                 }
             }
         }

--- a/UMM/View/Record/InterimPastView.swift
+++ b/UMM/View/Record/InterimPastView.swift
@@ -31,7 +31,7 @@ struct InterimPastView: View {
                     .font(.custom(FontsManager.Pretendard.medium, size: 16))
                     .foregroundStyle(Color(0xA6A6A6))
                 
-            } else if pastCnt <= 6 {
+            } else if pastCnt <= Constants.travelCnt {
                 VStack {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0..<pastCnt, id: \.self) { index in
@@ -47,10 +47,10 @@ struct InterimPastView: View {
                 ZStack {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
-                            ForEach(0 ..< (pastCnt+5)/6, id: \.self) { page in
+                            ForEach(0 ..< (pastCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { page in
                                 VStack {
                                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                        ForEach((page * 6) ..< min((page+1) * 6, pastCnt), id: \.self) { index in
+                                        ForEach((page * Constants.travelCnt) ..< min((page+1) * Constants.travelCnt, pastCnt), id: \.self) { index in
                                             TravelButtonView(viewModel: viewModel, travel: previousTravel?[index] ?? Travel(), travelCnt: pastCnt, isSelectedTravel: $isSelectedTravel)
                                         }
                                     }
@@ -70,7 +70,7 @@ struct InterimPastView: View {
                                 .frame(width: 5, height: 5)
                         }
                     }
-                    .offset(y: 95)
+                    .offset(y: Constants.interimOffset)
                 }
             }
         }

--- a/UMM/View/Record/InterimProceedingView.swift
+++ b/UMM/View/Record/InterimProceedingView.swift
@@ -31,7 +31,7 @@ struct InterimProceedingView: View {
                     .font(.custom(FontsManager.Pretendard.medium, size: 16))
                     .foregroundStyle(Color(0xA6A6A6))
                 
-            } else if proceedingCnt <= 6 {
+            } else if proceedingCnt <= Constants.travelCnt {
                 VStack {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0..<proceedingCnt, id: \.self) { index in
@@ -47,10 +47,10 @@ struct InterimProceedingView: View {
                 ZStack {
                       ScrollView(.init()) {
                           TabView(selection: $currentPage) {
-                              ForEach(0 ..< (proceedingCnt+5)/6, id: \.self) { page in
+                              ForEach(0 ..< (proceedingCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { page in
                                   VStack {
                                       LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                          ForEach((page * 6) ..< min((page+1) * 6, proceedingCnt), id: \.self) { index in
+                                          ForEach((page * Constants.travelCnt) ..< min((page+1) * Constants.travelCnt, proceedingCnt), id: \.self) { index in
                                               TravelButtonView(viewModel: viewModel, travel: nowTravel?[index] ?? Travel(), travelCnt: proceedingCnt, isSelectedTravel: $isSelectedTravel)
                                           }
                                       }
@@ -64,13 +64,13 @@ struct InterimProceedingView: View {
                       }
                       
                       HStack(spacing: 6) {
-                          ForEach(0..<(proceedingCnt+5)/6, id: \.self) { index in
+                          ForEach(0..<(proceedingCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { index in
                               Capsule()
                                   .fill(currentPage == index ? Color.black : Color.gray200)
                                   .frame(width: 5, height: 5)
                           }
                       }
-                      .offset(y: 95)
+                      .offset(y: Constants.interimOffset)
                   }
             }
         }

--- a/UMM/View/Travel/PreviousTravelView.swift
+++ b/UMM/View/Travel/PreviousTravelView.swift
@@ -27,7 +27,7 @@ struct PreviousTravelView: View {
             if travelCnt == 0 {
                 Text("지난 여행 내역이 없어요")
                     .foregroundStyle(Color(0xA6A6A6))
-            } else if travelCnt <= 6 {
+            } else if travelCnt <= Constants.travelCnt {
                 VStack {
                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
                         ForEach(0 ..< travelCnt, id: \.self) { index in
@@ -44,10 +44,10 @@ struct PreviousTravelView: View {
               ZStack {
                     ScrollView(.init()) {
                         TabView(selection: $currentPage) {
-                            ForEach(0 ..< (travelCnt+5)/6, id: \.self) { page in
+                            ForEach(0 ..< (travelCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { page in
                                 VStack {
                                     LazyVGrid(columns: Array(repeating: GridItem(), count: 3)) {
-                                        ForEach((page * 6) ..< min((page+1) * 6, travelCnt), id: \.self) { index in
+                                        ForEach((page * Constants.travelCnt) ..< min((page+1) * Constants.travelCnt, travelCnt), id: \.self) { index in
                                             TravelItemView(travel: previousTravel?[index] ?? Travel(), travelCnt: travelCnt)
                                         }
                                     }
@@ -61,14 +61,14 @@ struct PreviousTravelView: View {
                     }
                     
                     HStack(spacing: 6) {
-                        ForEach(0..<(travelCnt+5)/6, id: \.self) { index in
+                        ForEach(0..<(travelCnt+Constants.travelCnt-1)/Constants.travelCnt, id: \.self) { index in
                             Capsule()
                                 .fill(currentPage == index ? Color.black : Color.gray200)
                                 .frame(width: 5, height: 5)
                         }
                     }
                     // TempView 가 있을 땐 125 없을 땐 85
-                    .offset(y: 125)
+                    .offset(y: Constants.indicatorOffset)
                 }
             }
         }

--- a/UMM/View/Travel/TravelButtonView.swift
+++ b/UMM/View/Travel/TravelButtonView.swift
@@ -46,7 +46,6 @@ struct TravelButtonView: View {
                 }
                 isSelectedTravel = (chosenTravel != nil)
                 viewModel.chosenTravel = chosenTravel
-                print("iiii \(viewModel.chosenTravel)")
             } label: {
                 ZStack {
                     if let imageString = {
@@ -55,7 +54,7 @@ struct TravelButtonView: View {
                         Image(imageString)
                             .resizable()
                             .scaledToFill()
-                            .frame(width: 110, height: 80)
+                            .frame(width: Constants.frameWidth, height: Constants.frameHeight)
                             .cornerRadius(10)
                             .overlay(
                                 LinearGradient(
@@ -147,11 +146,11 @@ struct TravelButtonView: View {
                     }
                     
                     RoundedRectangle(cornerRadius: 10)
-                        .frame(width: 110, height: 80)
+                        .frame(width: Constants.frameWidth, height: Constants.frameHeight)
                         .foregroundStyle(.gray100)
                         .opacity(viewModel.chosenTravel == travel ? 0.0 : 0.4)
                 }
-                .frame(width: 110, height: 80)
+                .frame(width: Constants.frameWidth, height: Constants.frameHeight)
                 .onAppear {
                     
                     viewModel.fetchTravel()
@@ -194,11 +193,6 @@ struct TravelButtonView: View {
                 .font(.subhead1)
                 .lineLimit(1)
         }
-//        .onChange(of: chosenTravel) { _, newChosenTravel in
-//            if newChosenTravel != travel {
-//                chosenTravel = nil
-//            }
-//        }
     }
 }
 

--- a/UMM/View/Travel/TravelItemView.swift
+++ b/UMM/View/Travel/TravelItemView.swift
@@ -42,7 +42,7 @@ struct TravelItemView: View {
                             Image(imageString)
                                 .resizable()
                                 .scaledToFill()
-                                .frame(width: 110, height: 80)
+                                .frame(width: Constants.frameWidth, height: Constants.frameHeight)
                                 .cornerRadius(10)
                                 .overlay(
                                     LinearGradient(
@@ -104,7 +104,7 @@ struct TravelItemView: View {
                             .padding(.horizontal, 8)
                             .padding(.bottom, 8)
                         }
-                        .frame(width: 110, height: 80)
+                        .frame(width: Constants.frameWidth, height: Constants.frameHeight)
                     }
                     .onAppear {
                         

--- a/UMM/View/Travel/UpcomingTravelView.swift
+++ b/UMM/View/Travel/UpcomingTravelView.swift
@@ -66,8 +66,7 @@ struct UpcomingTravelView: View {
                                 .frame(width: 5, height: 5)
                         }
                     }
-                    // TempView 가 있을 땐 125 없을 땐 85
-                    .offset(y: 125)
+                    .offset(y: Constants.indicatorOffset)
                 }
             }
         }


### PR DESCRIPTION
## 👀 이슈
- #335 

## 💡 작업 내용
- SE화면 비율에서도 UI가 깨지지 않도록 하였습니다.

## 📱스크린샷
<img width="916" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/c703cc4b-6372-4d03-ba3f-52a8943efcd5">

<img width="888" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team11-UMM/assets/93391058/b44eeb13-3c7b-4362-9b23-aa8b48648767">

## 🚨 참고 사항

상수 구조체를 사용한 부분
- InterimRecordView의 여행 개수
- InterimRecordView의 offset 위치
- TravelButtonView의 frame 크기
- TravelItemView의 frame 크기
- 지난여행/다가오는 여행의 offset 위치

## (Optional) 🤔 고민한 점
앞으로 UIScreen을 쓰지 못한다면.... 수정해야합니다..🥹